### PR TITLE
Complete some schedule and results to-do's

### DIFF
--- a/pybaseball/team_results.py
+++ b/pybaseball/team_results.py
@@ -2,9 +2,9 @@ import numpy as np
 import pandas as pd
 import requests
 from bs4 import BeautifulSoup
+from datetime import datetime
+from pybaseball.utils import team_start_year
 
-# TODO: raise error if year > current year or < first year of a team's existence
-# TODO: sanitize team inputs (force to all caps)
 # TODO: retrieve data for all teams? a full season's worth of results
 
 def get_soup(season, team):
@@ -95,8 +95,19 @@ def make_numeric(data):
 
 def schedule_and_record(season=None, team=None):
     # retrieve html from baseball reference
+    team = team.upper()
+    try:
+        start_year = team_start_year[team]
+    except KeyError:
+        m = 'Please verify that your team abbreviation is accurate'
+        raise ValueError(m)
+    if season > datetime.now().year:
+        raise ValueError('Season cannot be after current year')
+    if season < start_year:
+        m = "Season cannot be before team's first year of existence"
+        raise ValueError(m)
     soup = get_soup(season, team)
-    table = get_table(soup,team)
+    table = get_table(soup, team)
     table = process_win_streak(table)
     table = make_numeric(table)
     return table

--- a/pybaseball/team_results.py
+++ b/pybaseball/team_results.py
@@ -3,8 +3,8 @@ import pandas as pd
 import requests
 from bs4 import BeautifulSoup
 from datetime import datetime
-from pybaseball.utils import team_start_year
 
+# TODO: raise error if year < first year of a team's existence
 # TODO: retrieve data for all teams? a full season's worth of results
 
 def get_soup(season, team):
@@ -96,16 +96,8 @@ def make_numeric(data):
 def schedule_and_record(season=None, team=None):
     # retrieve html from baseball reference
     team = team.upper()
-    try:
-        start_year = team_start_year[team]
-    except KeyError:
-        m = 'Please verify that team abbreviation is accurate'
-        raise ValueError(m)
     if season > datetime.now().year:
-        raise ValueError('Season cannot be after current year')
-    if season < start_year:
-        m = "Season cannot be before team's first year of existence"
-        raise ValueError(m)
+        raise ValueError('Season cannon be after current year')
     soup = get_soup(season, team)
     table = get_table(soup, team)
     table = process_win_streak(table)

--- a/pybaseball/team_results.py
+++ b/pybaseball/team_results.py
@@ -4,6 +4,7 @@ import requests
 from bs4 import BeautifulSoup
 from datetime import datetime
 from pybaseball.lahman import teams
+from pybaseball.utils import first_season_map
 
 # TODO: retrieve data for all teams? a full season's worth of results
 
@@ -97,20 +98,15 @@ def schedule_and_record(season=None, team=None):
     # retrieve html from baseball reference
     # sanatize input
     team = team.upper()
-    df = teams()
-    seasons = df['yearID']
-    team_names = df['teamIDBR']
-    first_occurrences = team_names.drop_duplicates(keep='first')
-    first_occurrences_index = first_occurrences.index.values
-    first_years = pd.DataFrame(seasons[first_occurrences_index])
-    first_years['teamID'] = first_occurrences
-    first_season_map = dict(zip(first_years['teamID'],
-                                first_years['yearID']))
-    if season < first_season_map[team]:
-        m = "Season cannot be before first year of a team's existence"
-        raise ValueError(m)
+    try:
+        if season < first_season_map[team]:
+            m = "Season cannot be before first year of a team's existence"
+            raise ValueError(m)
+    # ignore validation if team isn't found in dictionary
+    except KeyError:
+        pass
     if season > datetime.now().year:
-        raise ValueError('Season cannon be after current year')
+        raise ValueError('Season cannot be after current year')
 
     soup = get_soup(season, team)
     table = get_table(soup, team)

--- a/pybaseball/team_results.py
+++ b/pybaseball/team_results.py
@@ -99,7 +99,7 @@ def schedule_and_record(season=None, team=None):
     try:
         start_year = team_start_year[team]
     except KeyError:
-        m = 'Please verify that your team abbreviation is accurate'
+        m = 'Please verify that team abbreviation is accurate'
         raise ValueError(m)
     if season > datetime.now().year:
         raise ValueError('Season cannot be after current year')

--- a/pybaseball/utils.py
+++ b/pybaseball/utils.py
@@ -4,6 +4,16 @@ import datetime
 import io
 
 
+team_start_year = {'LAA': 1961, 'HOU': 1962, 'OAK': 1901, 'TOR': 1977,
+                   'TB': 1998, 'CLE': 1901, 'SEA': 1977, 'BAL': 1901,
+                   'TEX': 1961, 'BOS': 1901, 'KC': 1969, 'KRC': 1969,
+                   'DET': 1901, 'MIN': 1901, 'CHW': 1901, 'NYY': 1903,
+                   'ATL': 1871, 'MIL': 1997, 'STL': 1882, 'CHC': 1874,
+                   'ARI': 1998, 'LAD': 1884, 'SF': 1883, 'SFG': 1883,
+                   'MIA': 1993, 'NYM': 1962, 'WSN': 1969, 'SDP': 1883,
+                   'PHI': 1883, 'PIT': 1882, 'CIN': 1882, 'COL': 1993}
+
+
 def validate_datestring(date_text):
     try:
         datetime.datetime.strptime(date_text, '%Y-%m-%d')

--- a/pybaseball/utils.py
+++ b/pybaseball/utils.py
@@ -4,16 +4,6 @@ import datetime
 import io
 
 
-team_start_year = {'LAA': 1961, 'HOU': 1962, 'OAK': 1901, 'TOR': 1977,
-                   'TB': 1998, 'CLE': 1901, 'SEA': 1977, 'BAL': 1901,
-                   'TEX': 1961, 'BOS': 1901, 'KC': 1969, 'KRC': 1969,
-                   'DET': 1901, 'MIN': 1901, 'CHW': 1901, 'NYY': 1903,
-                   'ATL': 1871, 'MIL': 1997, 'STL': 1882, 'CHC': 1874,
-                   'ARI': 1998, 'LAD': 1884, 'SF': 1883, 'SFG': 1883,
-                   'MIA': 1993, 'NYM': 1962, 'WSN': 1969, 'SDP': 1883,
-                   'PHI': 1883, 'PIT': 1882, 'CIN': 1882, 'COL': 1993}
-
-
 def validate_datestring(date_text):
     try:
         datetime.datetime.strptime(date_text, '%Y-%m-%d')

--- a/pybaseball/utils.py
+++ b/pybaseball/utils.py
@@ -5,6 +5,35 @@ import io
 import zipfile
 
 
+# dictionary containing team abbreviations and their first year in existance
+first_season_map = {'ALT': 1884, 'ANA': 1997, 'ARI': 1998, 'ATH': 1871,
+                    'ATL': 1966, 'BAL': 1872, 'BLA': 1901, 'BLN': 1892,
+                    'BLU': 1884, 'BOS': 1871, 'BRA': 1872, 'BRG': 1890,
+                    'BRO': 1884, 'BSN': 1876, 'BTT': 1914, 'BUF': 1879,
+                    'BWW': 1890, 'CAL': 1965, 'CEN': 1875, 'CHC': 1876,
+                    'CHI': 1871, 'CHW': 1901, 'CIN': 1876, 'CKK': 1891,
+                    'CLE': 1871, 'CLV': 1879, 'COL': 1883, 'COR': 1884,
+                    'CPI': 1884, 'DET': 1901, 'DTN': 1881, 'ECK': 1872,
+                    'FLA': 1993, 'HAR': 1874, 'HOU': 1962, 'IND': 1878,
+                    'KCA': 1955, 'KCC': 1884, 'KCN': 1886, 'KCP': 1914,
+                    'KCR': 1969, 'KEK': 1871, 'LAA': 1961, 'LAD': 1958,
+                    'LOU': 1876, 'MAN': 1872, 'MAR': 1873, 'MIA': 2012,
+                    'MIL': 1884, 'MIN': 1961, 'MLA': 1901, 'MLG': 1878,
+                    'MLN': 1953, 'MON': 1969, 'NAT': 1872, 'NEW': 1915,
+                    'NHV': 1875, 'NYG': 1883, 'NYI': 1890, 'NYM': 1962,
+                    'NYP': 1883, 'NYU': 1871, 'NYY': 1903, 'OAK': 1968,
+                    'OLY': 1871, 'PBB': 1890, 'PBS': 1914, 'PHA': 1882,
+                    'PHI': 1873, 'PHK': 1884, 'PHQ': 1890, 'PIT': 1882,
+                    'PRO': 1878, 'RES': 1873, 'RIC': 1884, 'ROC': 1890,
+                    'ROK': 1871, 'SDP': 1969, 'SEA': 1977, 'SEP': 1969,
+                    'SFG': 1958, 'SLB': 1902, 'SLM': 1884, 'SLR': 1875,
+                    'STL': 1875, 'STP': 1884, 'SYR': 1879, 'TBD': 1998,
+                    'TBR': 2008, 'TEX': 1972, 'TOL': 1884, 'TOR': 1977,
+                    'TRO': 1871, 'WAS': 1873, 'WES': 1875, 'WHS': 1884,
+                    'WIL': 1884, 'WOR': 1880, 'WSA': 1961, 'WSH': 1901,
+                    'WSN': 2005}
+
+
 def validate_datestring(date_text):
     try:
         datetime.datetime.strptime(date_text, '%Y-%m-%d')


### PR DESCRIPTION
This PR takes care of a couple of the to-do's in `team_results.py`. I've capitalized the team abbreviation and raised an error when season is greater than the current year.

I started to take work on raising an error when the season is before the team's first season and adding the capabilities to return results for every team, but I realized it was more complicated than I originally thought it would be. My original idea was to just include a dictionary that contained each team's abbreviation and their start year, but there are a ton of historical teams that can currently be found with `schedule_and_records` so that dictionary would need to be huge to cover everyone. I think it would be better to wait and see if there's a better way to handle it.