### PR TITLE
Retrosheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Recent Updates**: Added [Statcast Single Game](https://github.com/jldbc/pybaseball/blob/master/docs/statcast_single_game.md) function, [Lahman database](https://github.com/jldbc/pybaseball/blob/master/docs/lahman.md), and bWAR acquisition functions for [batting](https://github.com/jldbc/pybaseball/blob/master/docs/bwar_bat.md) and [pitching](https://github.com/jldbc/pybaseball/blob/master/docs/bwar_pitch.md). [Release notes: [1.0.4](https://github.com/jldbc/pybaseball/releases/tag/1.0.4), [1.0.3](https://github.com/jldbc/pybaseball/releases/tag/1.0.3)].
 
-`pybaseball` is a Python package for baseball data analysis. This package scrapes Baseball Reference, Baseball Savant, and FanGraphs so you don't have to. The package retrieves statcast data, pitching stats, batting stats, division standings/team records, awards data, and more. Data is available at the individual pitch level, as well as aggregated at the season level and over custom time periods. See the [docs](https://github.com/jldbc/pybaseball/tree/master/docs) for a comprehensive list of data acquisition functions. 
+`pybaseball` is a Python package for baseball data analysis. This package scrapes Baseball Reference, Baseball Savant, and FanGraphs so you don't have to. The package retrieves statcast data, pitching stats, batting stats, division standings/team records, awards data, and more. Data is available at the individual pitch level, as well as aggregated at the season level and over custom time periods. See the [docs](https://github.com/jldbc/pybaseball/tree/master/docs) for a comprehensive list of data acquisition functions.
 
 ## Installation
 
@@ -24,7 +24,7 @@ python setup.py install
 
 ## Statcast: Pull advanced metrics from Major League Baseball's Statcast system
 
-Statcast data include pitch-level features such as Perceived Velocity (PV), Spin Rate (SR), Exit Velocity (EV), pitch X, Y, and Z coordinates, and more. The function `statcast(start_dt, end_dt)` pulls this data from baseballsavant.com. 
+Statcast data include pitch-level features such as Perceived Velocity (PV), Spin Rate (SR), Exit Velocity (EV), pitch X, Y, and Z coordinates, and more. The function `statcast(start_dt, end_dt)` pulls this data from baseballsavant.com.
 
 ```python
 >>> from pybaseball import statcast
@@ -51,7 +51,7 @@ Statcast data include pitch-level features such as Perceived Velocity (PV), Spin
 
 If `start_dt` and `end_dt` are supplied, it will return all statcast data between those two dates. If not, it will return yesterday's data. The optional argument `verbose` will control whether the library updates you on its progress while it pulls the data.
 
-For a player-specific statcast query, pull pitching or batting data using the `statcast_pitcher` and `statcast_batter` functions. These take the same `start_dt` and `end_dt` arguments as the statcast function, as well as a `player_id` argument. This ID comes from MLB Advanced Media, and can be obtained using the function `playerid_lookup`. A complete example: 
+For a player-specific statcast query, pull pitching or batting data using the `statcast_pitcher` and `statcast_batter` functions. These take the same `start_dt` and `end_dt` arguments as the statcast function, as well as a `player_id` argument. This ID comes from MLB Advanced Media, and can be obtained using the function `playerid_lookup`. A complete example:
 
 ```python
 >>> # Find Clayton Kershaw's player id
@@ -66,7 +66,7 @@ Gathering player lookup table. This may take a moment.
    mlb_played_first  mlb_played_last
 0            2008.0           2017.0
 
->>> # His MLBAM ID is 477132, so we feed that as the player_id argument to the following function 
+>>> # His MLBAM ID is 477132, so we feed that as the player_id argument to the following function
 >>> kershaw_stats = statcast_pitcher('2017-06-01', '2017-07-01', 477132)
 >>> kershaw_stats.head(2)
   pitch_type   game_date release_speed release_pos_x release_pos_z  
@@ -94,7 +94,7 @@ Gathering player lookup table. This may take a moment.
 
 ## Pitching Stats: pitching stats for players across multiple seasons, single seasons, or during a specified time period
 
-This library contains two main functions for obtaining pitching data. For league-wide season-level pitching data, use the function `pitching_stats(start_season, end_season)`. This will return one row per player per season, and provide all metrics made available by FanGraphs. 
+This library contains two main functions for obtaining pitching data. For league-wide season-level pitching data, use the function `pitching_stats(start_season, end_season)`. This will return one row per player per season, and provide all metrics made available by FanGraphs.
 
 The second is `pitching_stats_range(start_dt, end_dt)`. This allows you to obtain pitching data over a specific time interval, allowing you to get more granular than the FanGraphs function (for example, to see which pitcher had the strongest month of May). This query pulls data from Baseball Reference. Note that all dates should be in `YYYY-MM-DD` format.
 
@@ -138,7 +138,7 @@ If you prefer Baseball Reference to FanGraphs, there is a third option called `p
 
 ## Batting Stats: hitting stats for players within seasons or during a specified time period
 
-Batting stats are obtained similar to pitching stats. The function call for getting a season-level stats is `batting_stats(start_season, end_season)`, and for a particular time range it is `batting_stats_range(start_dt, end_dt)`. The Baseball Reference equivalent for season-level data is `batting_stats_bref(season)`. 
+Batting stats are obtained similar to pitching stats. The function call for getting a season-level stats is `batting_stats(start_season, end_season)`, and for a particular time range it is `batting_stats_range(start_dt, end_dt)`. The Baseball Reference equivalent for season-level data is `batting_stats_bref(season)`.
 
 ```python
 >>> from pybaseball import batting_stats_range
@@ -161,8 +161,8 @@ Batting stats are obtained similar to pitching stats. The function call for gett
 [5 rows x 27 columns]
 ```
 
-## Game-by-Game Results and Schedule 
-The `schedule_and_record` function returns a team's game-by-game results for a given season, including game date, home and away teams, end result (W/L/Tie), score, winning/losing/saving pitchers, attendance, and division standing at that date. The function's only two arguments are `season` and `team`, where team is the team's abbreviation (i.e. NYY for New York Yankees, SEA for Seattle Mariners). If the season argument is set to the current season, the query returns results for past games and the schedule for those that have not occurred yet. 
+## Game-by-Game Results and Schedule
+The `schedule_and_record` function returns a team's game-by-game results for a given season, including game date, home and away teams, end result (W/L/Tie), score, winning/losing/saving pitchers, attendance, and division standing at that date. The function's only two arguments are `season` and `team`, where team is the team's abbreviation (i.e. NYY for New York Yankees, SEA for Seattle Mariners). If the season argument is set to the current season, the query returns results for past games and the schedule for those that have not occurred yet.
 
 ```python
 # Example: Let's take a look at the individual-game results of the 1927 Yankees
@@ -187,9 +187,9 @@ The `schedule_and_record` function returns a team's game-by-game results for a g
 
 ## Standings: up to date or historical division standings, W/L records
 
-The `standings(season)` function gives division standings for a given season. If the current season is chosen, it will give the most current set of standings. Otherwise, it will give the end-of-season standings for each division for the chosen season. 
+The `standings(season)` function gives division standings for a given season. If the current season is chosen, it will give the most current set of standings. Otherwise, it will give the end-of-season standings for each division for the chosen season.
 
-This function returns a list of dataframes. Each dataframe is the standings for one of MLB's six divisions. 
+This function returns a list of dataframes. Each dataframe is the standings for one of MLB's six divisions.
 
 ```python
 >>> from pybaseball import standings
@@ -205,17 +205,17 @@ This function returns a list of dataframes. Each dataframe is the standings for 
 
 # Complete Documentation
 
-So far this has provided a basic overview of what this package can do and how you can use it. For full documentation on available functions and their arguments, see the [docs](https://github.com/jldbc/pybaseball/tree/master/docs) folder. 
+So far this has provided a basic overview of what this package can do and how you can use it. For full documentation on available functions and their arguments, see the [docs](https://github.com/jldbc/pybaseball/tree/master/docs) folder.
 
-# So what can I do with this? 
+# So what can I do with this?
 
 Need some inspiration? See some examples of classic baseball studies replicated using this package [here](https://github.com/jldbc/pybaseball/tree/master/EXAMPLES).
 
 ------
 
-## Credit 
+## Credit
 
-This pacakge was inspired by Bill Petti's excellent R package [baseballr](https://github.com/billpetti/baseballr), which at the time of this package's development had no Python equivalent. My hope is to fill that void with this package. 
+This pacakge was inspired by Bill Petti's excellent R package [baseballr](https://github.com/billpetti/baseballr), which at the time of this package's development had no Python equivalent. My hope is to fill that void with this package.
 
 The Lahman data comes from [Sean Lahman's baseball database](http://www.seanlahman.com/baseball-archive/statistics/).
 
@@ -229,4 +229,4 @@ Moving forward, I intend to:
 * Identify edge cases where these queries fail (please open up an issue if you find one!)
 * Add more examples
 
-Interested in contributing? I've left some ideas in [contributing.md](https://github.com/jldbc/pybaseball/tree/master/contributing.md). 
+Interested in contributing? I've left some ideas in [contributing.md](https://github.com/jldbc/pybaseball/tree/master/contributing.md).

--- a/docs/retrosheet.md
+++ b/docs/retrosheet.md
@@ -1,6 +1,6 @@
 # Retrosheet
 
-The functions in `retrosheet.py` retrieve game log data from [Retrosheet.org](http://www.retrosheet.org/gamelogs/index.html).
+The functions in `retrosheet.py` retrieve game logs, rosters, schedules, park codes and event files by Retrosheet from [the Chadwick Bureau Github](https://github.com/chadwickbureau/retrosheet).
 
 ## Retrosheet Data Notice
 
@@ -34,3 +34,11 @@ discovers discrepancies and we appreciate learning of the details.
 `division_series_logs`: Retrieve game logs from all Division Series Games.
 
 `lcs_logs()`: Retrieve game logs from all LCS games.
+
+`schedule(season)`: Retrieve all scheduled games and postponements for a given season.
+
+`park_codes()`: Retrieves the park codes used by retrosheet.
+
+`rosters(season)`: Retrieves all major league rosters for a given season.
+
+`events(season, type='regular', export_dir='.')`: Downloads the event files from retrosheet. `type` can be one of `regular`, `post`, or `asg`. The files are saved in the specified export directory.

--- a/docs/retrosheet.md
+++ b/docs/retrosheet.md
@@ -23,6 +23,12 @@ material presented here. All information is subject to corrections
 as additional data are received. We are grateful to anyone who
 discovers discrepancies and we appreciate learning of the details.
 
+## Extra Setup (Optional)
+
+When pulling retrosheet data, the request is checked against the files in the Chadwick Bureau retrosheet Github repository. The Github API has a rate limit of 60 queries per hour for non-registered queries. To register your connection and raise your rate limit to 5000 queries per hour, follow [this guide](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) once you've signed up for a Github account. On a MAC/Linux system, add `GH_TOKEN=<your_token>` to your `.bashrc` file. On Windows, add `GH_TOKEN` to your environment variables via the Start menu.
+
+Note this isn't required, but will provide you with more instructive errors as your queries will be checked against existing files before downloading.
+
 `season_game_logs(season)`: Retrieve game logs for a given season.
 
 `world_series_logs()`: Retrieve game logs from all World Series games.

--- a/docs/retrosheet.md
+++ b/docs/retrosheet.md
@@ -35,7 +35,7 @@ discovers discrepancies and we appreciate learning of the details.
 
 `lcs_logs()`: Retrieve game logs from all LCS games.
 
-`schedule(season)`: Retrieve all scheduled games and postponements for a given season.
+`schedules(season)`: Retrieve all scheduled games and postponements for a given season.
 
 `park_codes()`: Retrieves the park codes used by retrosheet.
 

--- a/pybaseball/__init__.py
+++ b/pybaseball/__init__.py
@@ -51,3 +51,7 @@ from .retrosheet import all_star_game_logs
 from .retrosheet import wild_card_logs
 from .retrosheet import division_series_logs
 from .retrosheet import lcs_logs
+from .retrosheet import events
+from .retrosheet import rosters
+from .retrosheet import park_codes
+from .retrosheet import schedules

--- a/pybaseball/retrosheet.py
+++ b/pybaseball/retrosheet.py
@@ -106,7 +106,7 @@ parkid_url = 'https://raw.githubusercontent.com/chadwickbureau/retrosheet/master
 roster_url = 'https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/rosters/{}{}.ROS'
 event_url = 'https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/event/{}/{}'
 
-def get_events(season, type='regular', export_dir='.'):
+def events(season, type='regular', export_dir='.'):
     """
     Pulls retrosheet event files for an entire season. The `type` argument
     specifies whether to pull regular season, postseason or asg files.
@@ -146,7 +146,7 @@ def get_events(season, type='regular', export_dir='.'):
         with open(os.path.join(export_dir, filename), 'w') as f:
             f.write(s)
 
-def get_rosters_season(season):
+def rosters(season):
     """
     Pulls retrosheet roster files for an entire season
     """
@@ -173,7 +173,7 @@ def get_rosters_season(season):
 
     return pd.concat(df_list)
 
-def get_roster(team, season, checked = False):
+def _roster(team, season, checked = False):
     """
     Pulls retrosheet roster files
     """
@@ -203,7 +203,7 @@ def get_roster(team, season, checked = False):
     data.columns = roster_columns
     return data
 
-def get_parkcodes():
+def park_codes():
     """
     Pulls retrosheet Park IDs
     """
@@ -212,7 +212,7 @@ def get_parkcodes():
     data.columns = parkcode_columns
     return data
 
-def get_schedule(season):
+def schedule(season):
     """
     Pull retrosheet schedule for a given season
     """

--- a/pybaseball/retrosheet.py
+++ b/pybaseball/retrosheet.py
@@ -212,7 +212,7 @@ def park_codes():
     data.columns = parkcode_columns
     return data
 
-def schedule(season):
+def schedules(season):
     """
     Pull retrosheet schedule for a given season
     """

--- a/pybaseball/retrosheet.py
+++ b/pybaseball/retrosheet.py
@@ -89,8 +89,23 @@ schedule_columns = [
     'date_of_makeup'
 ]
 
+parkcode_columns = [
+    'park_id', 'name', 'nickname', 'city', 'state', 'open', 'close', 'league', 'notes'
+]
+
 gamelog_url = 'https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/gamelog/GL{}.TXT'
 schedule_url = 'https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/schedule/{}SKED.TXT'
+parkid_url = 'https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/misc/parkcode.txt'
+
+def get_parkcodes():
+    """
+    Pulls retrosheet Park IDs
+    """
+    s = get_text_file(parkid_url)
+    data = pd.read_csv(StringIO(s), sep=',', quotechar='"')
+    data.columns = parkcode_columns
+    return data
+
 
 def get_schedule(season):
     """

--- a/pybaseball/retrosheet.py
+++ b/pybaseball/retrosheet.py
@@ -82,7 +82,32 @@ gamelog_columns = [
     'acquisition_info'
 ]
 
+schedule_columns = [
+    'date', 'game_num', 'day_of_week', 'visiting_team', 'visiting_team_league',
+    'visiting_team_game_num', 'home_team', 'home_team_league',
+    'home_team_game_num', 'day_night', 'postponement_cancellation',
+    'date_of_makeup'
+]
+
 gamelog_url = 'https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/gamelog/GL{}.TXT'
+schedule_url = 'https://raw.githubusercontent.com/chadwickbureau/retrosheet/master/schedule/{}SKED.TXT'
+
+def get_schedule(season):
+    """
+    Pull retrosheet schedule for a given season
+    """
+    # validate input
+    g = Github()
+    repo = g.get_repo('chadwickbureau/retrosheet')
+    schedules = [f.path[f.path.rfind('/')+1:] for f in repo.get_contents('schedule')]
+    file_name = '{}SKED.TXT'.format(season)
+
+    if file_name not in schedules:
+        raise ValueError('Schedule not available for {}'.format(season))
+    s = get_text_file(schedule_url.format(season))
+    data = pd.read_csv(StringIO(s), header=None, sep=',', quotechar='"')
+    data.columns = schedule_columns
+    return data
 
 def season_game_logs(season):
     """

--- a/pybaseball/utils.py
+++ b/pybaseball/utils.py
@@ -99,3 +99,13 @@ def get_zip_file(url):
     with requests.get(url, stream=True) as f:
         z = zipfile.ZipFile(io.BytesIO(f.content))
     return z
+
+def get_text_file(url):
+    """
+    Get raw github file from provided URL
+    """
+
+    with requests.get(url, stream=True) as f:
+        s = f.text
+
+    return s

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.8',
+    version='1.0.9',
 
     description='Retrieve baseball data in Python',
     long_description=long_description,
@@ -84,11 +84,12 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['numpy>=1.13.0', 
+    install_requires=['numpy>=1.13.0',
                       'pandas >= 0.20.2',
                       'beautifulsoup4>=4.4.0',
                       'requests>=2.18.1',
-                      'lxml>=4.2.1'
+                      'lxml>=4.2.1',
+                      'PyGithub>=1.51'
                       ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
This is the first of two PRs I'd like to contribute to add retrosheet data to pybaseball. Included in this PR:
- Changed Retrosheet file source to the Chadwick bureau Github. This avoids having to hardcode a max/min date assumption as Retrosheet is always adding data. This does require PyGithub in order to verify that files exist before they're downloaded.
- Added functions to pull schedules, rosters, park codes and event files (no parsing of event files is done yet)
- I bumped the version (though you may want to see that you agree with the new version)
- Added docs for new functions and additional (optional) setup for allowing more PyGithub queries with a CLI access token