### PR TITLE
Fix Markdown Syntax in Docs (ref:Lahman)

### DIFF
--- a/docs/lahman.md
+++ b/docs/lahman.md
@@ -1,6 +1,6 @@
 # Lahman Data Acquisition Functions
 
-Pull data from [Sean Lahman's database](http://www.seanlahman.com/baseball-archive/statistics/, also hosted by Chadwick Bureau on GitHub -- our new source) using the following functions:
+Pull data from [Sean Lahman's database](http://www.seanlahman.com/baseball-archive/statistics/), also hosted by Chadwick Bureau on GitHub -- our new source) using the following functions:
 
 ```python
 from pybaseball.lahman import *


### PR DESCRIPTION
Adds the closing parenthesis to satisfy the Markdown syntax of displaying links.  The fix gives the doc page better readability and restores it so it can serve as the author intended.