### PR TITLE
Drop old indexes when resetting index

### DIFF
--- a/pybaseball/playerid_lookup.py
+++ b/pybaseball/playerid_lookup.py
@@ -74,8 +74,9 @@ def playerid_lookup(last=None, first=None, player_list=None):
         results = table.loc[table['name_last'] == last]
     else:
         results = table.loc[(table['name_last'] == last) & (table['name_first'] == first)]
-    #results[['key_mlbam', 'key_fangraphs', 'mlb_played_first', 'mlb_played_last']] = results[['key_mlbam', 'key_fangraphs', 'mlb_played_first', 'mlb_played_last']].astype(int) # originally returned as floats which is wrong
-    results = results.reset_index().drop('index', 1)
+
+    results = results.reset_index(drop=True)
+
     return results
 
 
@@ -110,5 +111,6 @@ def playerid_reverse_lookup(player_ids, key_type=None):
     key = 'key_{}'.format(key_type)
 
     results = table[table[key].isin(player_ids)]
-    results = results.reset_index().drop('index', 1)
+    results = results.reset_index(drop=True)
+
     return results

--- a/pybaseball/statcast.py
+++ b/pybaseball/statcast.py
@@ -171,7 +171,9 @@ def postprocessing(data, team):
         data = data.loc[(data['home_team']==team)|(data['away_team']==team)]
     elif(team != None):
         raise ValueError('Error: invalid team abbreviation. Valid team names are: {}'.format(valid_teams))
-    data = data.reset_index()
+
+    data = data.reset_index(drop=True)
+
     return data
 
 def statcast(start_dt=None, end_dt=None, team=None, verbose=True):


### PR DESCRIPTION
Fixes the bug mentioned in #25. Also fixed up some formatting and long lines found via pylint and autopep8.
(closes #25)