### PR TITLE
updates setup.py to find submodules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=['pybaseball'],
+    packages=find_packages(exclude=["tests", "tests.*"]),
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:


### PR DESCRIPTION
With the addition of submodules, the `setup.py` needs to be updated so they will be installed with the package. This PR adds `find_packages` in the setup, excluding the `tests` dir. Closes https://github.com/jldbc/pybaseball/issues/109