### PR TITLE
removes python style comment from gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 EXAMPLES/* linguist-vendored
-*.csv linguist-vendored # Ignore supporting data files
-*.html linguist-vendored # Ignore supporting html files
+*.csv linguist-vendored
+*.html linguist-vendored


### PR DESCRIPTION
I'm seeing a noisy warning every time I use git on the command line, i.e. 
```
# is not a valid attribute name: .gitattributes:2
```

Presumable the # character isn't a valid comment delimiter in a `.gitattributes` file? This PR removes those comments.
