### PR TITLE
Fix issues with standings bref api; add integration tests

### DIFF
--- a/pybaseball/standings.py
+++ b/pybaseball/standings.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 
 import pandas as pd
 import requests

--- a/pybaseball/standings.py
+++ b/pybaseball/standings.py
@@ -1,8 +1,10 @@
-from bs4 import BeautifulSoup
-from bs4 import Comment
-import requests
 import datetime
-import pandas as pd 
+import re
+
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup, Comment
+
 
 def get_soup(year):
     url = 'http://www.baseball-reference.com/leagues/MLB/{}-standings.shtml'.format(year)
@@ -11,8 +13,12 @@ def get_soup(year):
 
 def get_tables(soup, season):
     datasets = []
-    if(season>=1969):
+    if season >= 1969:
         tables = soup.find_all('table')
+        if season == 1981:
+            # For some reason BRef has 1981 broken down by halves and overall
+            # https://www.baseball-reference.com/leagues/MLB/1981-standings.shtml
+            tables = [x for x in tables if 'overall' in x.get('id', '')]
         for table in tables:
             data = []
             headings = [th.get_text() for th in table.find("tr").find_all("th")]
@@ -30,24 +36,31 @@ def get_tables(soup, season):
         table = soup.find('table')
         headings = [th.get_text() for th in table.find("tr").find_all("th")]
         headings[0] = "Name"
-        if(season>=1930):
-            for i in range(15): headings.pop()
-        elif(season>=1876): 
-            for i in range(14): headings.pop()
+        if season >= 1930:
+            for i in range(15):
+                headings.pop()
+        elif season >= 1876:
+            for i in range(14):
+                headings.pop()
         else:
-            for i in range(16): headings.pop()
+            for i in range(16):
+                headings.pop()
         data.append(headings)
         table_body = table.find('tbody')
         rows = table_body.find_all('tr')
         for row in rows:
-            if row.find_all('a') == []: continue
+            if row.find_all('a') == []:
+                continue
             cols = row.find_all('td')
-            if(season>=1930):
-                for i in range(15): cols.pop()
-            elif(season>=1876): 
-                for i in range(14): cols.pop()
+            if season >= 1930:
+                for i in range(15):
+                    cols.pop()
+            elif season >= 1876:
+                for i in range(14):
+                    cols.pop()
             else:
-                for i in range(16): cols.pop()
+                for i in range(16):
+                    cols.pop()
             cols = [ele.text.strip() for ele in cols]
             cols.insert(0,row.find_all('a')[0]['title']) # team name
             data.append([ele for ele in cols if ele])
@@ -59,20 +72,22 @@ def get_tables(soup, season):
 
 def standings(season=None):
     # get most recent standings if date not specified
-    if(season is None):
+    if season is None:
         season = int(datetime.datetime.today().strftime("%Y"))
-    if season<1871:
+    if season < 1871:
         raise ValueError("This query currently only returns standings until the 1871 season. Try looking at years from 1871 to present.")
     # retrieve html from baseball reference
     soup = get_soup(season)
-    if season>=1969:
+    if season >= 1969:
         tables = get_tables(soup, season)
     else:
         t = soup.find_all(string=lambda text:isinstance(text,Comment))
         # list of seasons whose table placement breaks the site's usual pattern
         exceptions = [1884, 1885, 1886, 1887, 1888, 1889, 1890, 1892, 1903]
-        if (season>1904 or season in exceptions): code = BeautifulSoup(t[16], "lxml")
-        elif season<=1904: code = BeautifulSoup(t[15], "lxml")
+        if season>1904 or season in exceptions:
+            code = BeautifulSoup(t[27], "lxml")
+        elif season <= 1904:
+            code = BeautifulSoup(t[26], "lxml")
         tables = get_tables(code, season)
     tables = [pd.DataFrame(table) for table in tables]
     for idx in range(len(tables)):

--- a/pybaseball/standings.py
+++ b/pybaseball/standings.py
@@ -83,7 +83,7 @@ def standings(season=None):
         t = soup.find_all(string=lambda text:isinstance(text,Comment))
         # list of seasons whose table placement breaks the site's usual pattern
         exceptions = [1884, 1885, 1886, 1887, 1888, 1889, 1890, 1892, 1903]
-        if season>1904 or season in exceptions:
+        if season > 1904 or season in exceptions:
             code = BeautifulSoup(t[27], "lxml")
         elif season <= 1904:
             code = BeautifulSoup(t[26], "lxml")

--- a/tests/integration/pybaseball/test_standings.py
+++ b/tests/integration/pybaseball/test_standings.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from typing import List, Optional, Tuple
+
+import pandas as pd
+import pytest
+
+from pybaseball.standings import standings
+
+def get_division_counts_by_season(season: Optional[int]) -> int:
+    if season is None:
+        season = datetime.today().year
+
+    if season >= 1994:
+        return 6
+    if season >= 1969:
+        return 4
+    return 1
+
+class TestBRefStandings:
+    @pytest.mark.parametrize(
+        "season", [(x) for x in range(1871, datetime.today().year + 1)] + [(None)] # type: ignore
+    )
+    def test_standings(self, season: Optional[int]) -> None:
+        standings_list = standings(season)
+
+        assert standings_list is not None
+        assert len(standings_list) == get_division_counts_by_season(season)
+
+        for data in standings_list:
+            assert data is not None
+            assert not data.empty
+            assert len(data.columns) > 0
+            assert len(data.index) > 0
+
+    def test_standings_pre_1871(self) -> None:
+        season = 1870
+
+        with pytest.raises(ValueError):
+            standings(season)
+
+    def test_standings_future(self) -> None:
+        season = datetime.today().year + 1
+
+        standings_list = standings(season)
+
+        assert standings_list == []


### PR DESCRIPTION
This PR accomplishes two things:

1. Adds integration tests to the standings function, which was our code with the lowest coverage (only 11% under test).
2. While adding those integration tests, I discovered that due to an issue with BRef, all pre-1969 standings were erroring out.  As well I discovered that for 1981, we weren't accurately pulling the standings due to a quirk in BRef. So this fixes those issues as well.

So hooray for tests! They help us to catch bugs before our users do.