### PR TITLE
Fix broken test; split out unit tests from integration tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,7 +22,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[test]
       - name: Run tests
-        run: pytest
+        run: pytest tests --doctest-modules --cov=pybaseball --cov-report term-missing
       - name: Run MyPy
         run: mypy .
         continue-on-error: true

--- a/tests/integration/pybaseball/test_league_pitching_stats.py
+++ b/tests/integration/pybaseball/test_league_pitching_stats.py
@@ -1,5 +1,4 @@
 from datetime import date, datetime, timedelta
-from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/integration/pybaseball/test_league_pitching_stats.py
+++ b/tests/integration/pybaseball/test_league_pitching_stats.py
@@ -6,44 +6,6 @@ import pytest
 from pybaseball import league_pitching_stats
 
 
-def test_sanitize_input_none_none() -> None:
-    result1, result2 = league_pitching_stats.sanitize_input(None, None)
-    
-    assert datetime.strptime(result1, '%Y-%m-%d').date() == date.today() - timedelta(days=1)
-    assert datetime.strptime(result2, '%Y-%m-%d').date() == date.today()
-
-
-def test_sanitize_input_end_dt_none() -> None:
-    result1, result2 = league_pitching_stats.sanitize_input('2019-05-01', None)
-    
-    assert result1 == '2019-05-01'
-    assert result2 == result1
-
-
-def test_sanitize_input_start_dt_gt_end_dt() -> None:
-    result1, result2 = league_pitching_stats.sanitize_input('2019-07-01', '2019-06-01')
-
-    assert result1 == '2019-06-01'
-    assert result2 == '2019-07-01'
-
-
-def test_sanitize_input_start_dt_none() -> None:
-    result1, result2 = league_pitching_stats.sanitize_input(None, '2019-06-01')
-    
-    assert result2 == '2019-06-01'
-    assert result1 == result2
-
-
-def test_get_soup_none_none() -> None:
-    result = league_pitching_stats.get_soup(None, None)
-    assert result is None
-
-
-def test_pitching_stats_range_start_dt_lt_2008() -> None:
-    with pytest.raises(ValueError):
-        league_pitching_stats.pitching_stats_range('2007-01-01', '2019-01-01')
-
-
 def test_pitching_stats_bref() -> None:
     result = league_pitching_stats.pitching_stats_bref(2019)
 
@@ -52,15 +14,6 @@ def test_pitching_stats_bref() -> None:
 
     assert len(result.columns) == 40
     assert(len(result)) == 831
-
-def test_pitching_stats_bref_none() -> None:
-    pitching_stats_range_mock =  MagicMock()
-    this_year = date.today().year
-
-    with patch('pybaseball.league_pitching_stats.pitching_stats_range', pitching_stats_range_mock):
-        league_pitching_stats.pitching_stats_bref(None)
-
-    pitching_stats_range_mock.assert_called_once_with(f'{this_year}-03-01', f"{this_year}-11-01")
 
 
 def test_pitching_stats_bref_future() -> None:

--- a/tests/integration/pybaseball/test_league_pitching_stats.py
+++ b/tests/integration/pybaseball/test_league_pitching_stats.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, timedelta
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -52,15 +53,14 @@ def test_pitching_stats_bref() -> None:
     assert len(result.columns) == 40
     assert(len(result)) == 831
 
-
 def test_pitching_stats_bref_none() -> None:
-    result = league_pitching_stats.pitching_stats_bref(None)
+    pitching_stats_range_mock =  MagicMock()
+    this_year = date.today().year
 
-    assert result is not None
-    assert not result.empty
+    with patch('pybaseball.league_pitching_stats.pitching_stats_range', pitching_stats_range_mock):
+        league_pitching_stats.pitching_stats_bref(None)
 
-    assert len(result.columns) == 40
-    assert(len(result)) == 729
+    pitching_stats_range_mock.assert_called_once_with(f'{this_year}-03-01', f"{this_year}-11-01")
 
 
 def test_pitching_stats_bref_future() -> None:

--- a/tests/integration/pybaseball/test_league_pitching_stats.py
+++ b/tests/integration/pybaseball/test_league_pitching_stats.py
@@ -16,16 +16,6 @@ def test_pitching_stats_bref() -> None:
     assert(len(result)) == 831
 
 
-def test_pitching_stats_bref_future() -> None:
-    with pytest.raises(IndexError):
-        league_pitching_stats.pitching_stats_bref(datetime.today().year + 1)
-
-
-def test_pitching_stats_bref_bad_year() -> None:
-    with pytest.raises(ValueError):
-        league_pitching_stats.pitching_stats_bref('NOT A YEAR')
-
-
 def test_bwar_pitch() -> None:
     result = league_pitching_stats.bwar_pitch()
 

--- a/tests/pybaseball/test_league_pitching_stats.py
+++ b/tests/pybaseball/test_league_pitching_stats.py
@@ -44,6 +44,16 @@ def test_pitching_stats_range_start_dt_lt_2008() -> None:
         league_pitching_stats.pitching_stats_range('2007-01-01', '2019-01-01')
 
 
+def test_pitching_stats_bref_future() -> None:
+    with pytest.raises(IndexError):
+        league_pitching_stats.pitching_stats_bref(datetime.today().year + 1)
+
+
+def test_pitching_stats_bref_bad_year() -> None:
+    with pytest.raises(ValueError):
+        league_pitching_stats.pitching_stats_bref('NOT A YEAR')
+
+
 def test_pitching_stats_bref_none() -> None:
     pitching_stats_range_mock =  MagicMock()
     this_year = date.today().year

--- a/tests/pybaseball/test_league_pitching_stats.py
+++ b/tests/pybaseball/test_league_pitching_stats.py
@@ -1,0 +1,54 @@
+from datetime import date, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pybaseball import league_pitching_stats
+
+
+def test_sanitize_input_none_none() -> None:
+    result1, result2 = league_pitching_stats.sanitize_input(None, None)
+    
+    assert datetime.strptime(result1, '%Y-%m-%d').date() == date.today() - timedelta(days=1)
+    assert datetime.strptime(result2, '%Y-%m-%d').date() == date.today()
+
+
+def test_sanitize_input_end_dt_none() -> None:
+    result1, result2 = league_pitching_stats.sanitize_input('2019-05-01', None)
+    
+    assert result1 == '2019-05-01'
+    assert result2 == result1
+
+
+def test_sanitize_input_start_dt_gt_end_dt() -> None:
+    result1, result2 = league_pitching_stats.sanitize_input('2019-07-01', '2019-06-01')
+
+    assert result1 == '2019-06-01'
+    assert result2 == '2019-07-01'
+
+
+def test_sanitize_input_start_dt_none() -> None:
+    result1, result2 = league_pitching_stats.sanitize_input(None, '2019-06-01')
+    
+    assert result2 == '2019-06-01'
+    assert result1 == result2
+
+
+def test_get_soup_none_none() -> None:
+    result = league_pitching_stats.get_soup(None, None)
+    assert result is None
+
+
+def test_pitching_stats_range_start_dt_lt_2008() -> None:
+    with pytest.raises(ValueError):
+        league_pitching_stats.pitching_stats_range('2007-01-01', '2019-01-01')
+
+
+def test_pitching_stats_bref_none() -> None:
+    pitching_stats_range_mock =  MagicMock()
+    this_year = date.today().year
+
+    with patch('pybaseball.league_pitching_stats.pitching_stats_range', pitching_stats_range_mock):
+        league_pitching_stats.pitching_stats_bref(None)
+
+    pitching_stats_range_mock.assert_called_once_with(f'{this_year}-03-01', f"{this_year}-11-01")


### PR DESCRIPTION
This PR fixes a current broken unit test on master due to the fact that I forgot that `test_pitching_stats_bref_none` will pull current season's data, which of course changes every day 🤦 

So I turned it into a pure unit test. Which made me realize I'd put some unit tests in the integration test file, so I rectified that as well.