### PR TITLE
Add function for playerID maps between data sources

### DIFF
--- a/pybaseball/playerid_mapping.py
+++ b/pybaseball/playerid_mapping.py
@@ -1,0 +1,13 @@
+import pandas as pd
+
+def playerid_mapping() -> pd.DataFrame:
+    """Returns a pandas DataFrame with player ID references for many available data sources
+    Includes 
+    - Player Name (first, last, MLB, FanGraphs, Yahoo, CBS, NFBC, FanDuel, ESPN, DraftKings, Rotowire, Razzball)
+    - Player ID (Fangraphs, MLB, CBS, Retrosheet, BBRef, NFBC, Baseball Prospectus, Yahoo, Rotowire, Fanduel)
+    - Team, League, Position
+
+    Returns:
+        pd.DataFrame: DataFrame from smartfantasybaseball, useful for merges across data sources
+    """
+    return pd.read_csv("https://www.smartfantasybaseball.com/PLAYERIDMAPCSV")


### PR DESCRIPTION
In my personal work, I find very often I'm trying to merge information from different data streams: maybe some info from Fangraphs, some from BP, etc. The common problem I run into is that the playerIDs are different in each data stream, so I typically will use a secondary data frame in order to combine the two, which includes the playerIDs from both data streams. E.G. merge dataframe A to the map on playerID A, then merge dataframe B to the map on playerID B.

The best one I've found is from smartfantasybaseball.com, preformatted into a CSV. This PR is effectively a one-liner that pulls that CSV into pandas. I feel a bit silly doing a PR and adding a new file for one line - perhaps there's a better way to go about this or it'd be better in an existing file, so happy to hear input if so. I figure we're supporting at least a few data streams, so this might provide useful.