### PR TITLE
Add misspelling suggestions to playerid_lookup

### DIFF
--- a/pybaseball/analysis/string_similarity.py
+++ b/pybaseball/analysis/string_similarity.py
@@ -1,0 +1,37 @@
+import numpy as np
+import numpy
+
+def levenshtein(seq1: str, seq2: str) -> np.int64:
+    """Gets the Levenshtein distance between 2 strings
+
+    Args:
+        seq1 (str): First string for comparison
+        seq2 (str): Second string for comparison
+
+    Returns:
+        np.int64: Levenshtein distance 
+    """
+    size_x = len(seq1) + 1
+    size_y = len(seq2) + 1
+    matrix = np.zeros ((size_x, size_y))
+    for x in range(size_x):
+        matrix [x, 0] = x
+    for y in range(size_y):
+        matrix [0, y] = y
+
+    for x in range(1, size_x):
+        for y in range(1, size_y):
+            if seq1[x-1] == seq2[y-1]:
+                matrix [x,y] = min(
+                    matrix[x-1, y] + 1,
+                    matrix[x-1, y-1],
+                    matrix[x, y-1] + 1
+                )
+            else:
+                matrix [x,y] = min(
+                    matrix[x-1,y] + 1,
+                    matrix[x-1,y-1] + 1,
+                    matrix[x,y-1] + 1
+                )
+
+    return (int(matrix[size_x - 1, size_y - 1]))

--- a/pybaseball/analysis/string_similarity.py
+++ b/pybaseball/analysis/string_similarity.py
@@ -1,5 +1,4 @@
 import numpy as np
-import numpy
 
 def levenshtein(seq1: str, seq2: str) -> np.int64:
     """Gets the Levenshtein distance between 2 strings

--- a/pybaseball/playerid_mapping.py
+++ b/pybaseball/playerid_mapping.py
@@ -1,0 +1,13 @@
+import pandas as pd
+
+def playerid_mapping() -> pd.DataFrame:
+    """Returns a pandas DataFrame with player ID references for many available data sources
+    Includes 
+    - Player Name (first, last, MLB, FanGraphs, Yahoo, CBS, NFBC, FanDuel, ESPN, DraftKings, Rotowire, Razzball)
+    - Player ID (Fangraphs, MLB, CBS, Retrosheet, BBRef, NFBC, Baseball Prospectus, Yahoo, Rotowire, Fanduel)
+    - Team, League, Position
+
+    Returns:
+        pd.DataFrame: DataFrame from smartfantasybaseball, useful for merges across data sources
+    """
+    return pd.read_csv("https://www.smartfantasybaseball.com/PLAYERIDMAPCSV")


### PR DESCRIPTION
Add spell checking on playerid_lookup. If the passed name to playerid_lookup does not have any matches, the Levenshtein distance is calculated for both the first and last names to a list of all player names, then those distances are summed. If the sum has a single minima, it raises a ValueError and suggests the single minima. If it has two, it will raise the ValueError and suggest both. If more than two, it just raises a ValueError with no suggestion.

Note, previously playerid_lookup did _not_ raise any errors if values were not found, it would only return an empty DF, so the raised errors will be new.

**Based on PR #160** - if #160  doesn't go in, this just needs to come up with a different methodology for getting a list of player names.

### Example output

One minima:

```
>>> playerid_lookup("turner","jstin")
Gathering player lookup table. This may take a moment.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tburch/Documents/github/pybaseball/pybaseball/playerid_lookup.py", line 103, in playerid_lookup
    raise ValueError(f"Player not found! Did you mean {suggested_first} {suggested_last}?")
ValueError: Player not found! Did you mean Justin Turner?
```

Two minima:

```
>>> playerid_lookup("Carpenter","B")
Gathering player lookup table. This may take a moment.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tburch/Documents/github/pybaseball/pybaseball/playerid_lookup.py", line 108, in playerid_lookup
    raise ValueError(f"Player not found! Perhaps you meant {suggested_first[0]} {suggested_last[0]} or {suggested_first[1]} {suggested_last[1]}?")
ValueError: Player not found! Perhaps you meant Matt Carpenter or Ryan Carpenter?
```
