### PR TITLE
Parallelize statcast calls

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,7 +22,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[test]
       - name: Run tests
-        run: pytest tests --doctest-modules --cov=pybaseball --cov-report term-missing
+        run: pytest tests --doctest-modules --cov=pybaseball --cov-report term-missing -n 5
       - name: Timing test
         timeout-minutes: 2
         run: python -m scripts.statcast_timing

--- a/pybaseball/statcast.py
+++ b/pybaseball/statcast.py
@@ -18,7 +18,7 @@ _SC_SMALL_REQUEST = "/statcast_search/csv?all=true&hfPT=&hfAB=&hfBBT=&hfPR=&hfZ=
 
 
 @cache.df_cache(expires=365)
-def _small_request(start_dt: date, end_dt: date, team: Optional[str] = None, verbose: bool = False) -> pd.DataFrame:
+def _small_request(start_dt: date, end_dt: date, team: Optional[str] = None) -> pd.DataFrame:
     data = statcast_ds.get_statcast_data_from_csv_url(
         _SC_SMALL_REQUEST.format(start_dt=str(start_dt), end_dt=str(end_dt), team=team if team else '')
     )
@@ -27,8 +27,6 @@ def _small_request(start_dt: date, end_dt: date, team: Optional[str] = None, ver
             ['game_date', 'game_pk', 'at_bat_number', 'pitch_number'],
             ascending=False
         )
-        if verbose:
-            print(f"Completed sub-query from {start_dt} to {end_dt} ({len(data)} results)")
 
     return data
 
@@ -63,7 +61,7 @@ def _handle_request(start_dt: date, end_dt: date, step: int, verbose: bool,
 
     with tqdm(total=len(date_range)) as progress:
         with concurrent.futures.ProcessPoolExecutor() as executor:
-            futures = {executor.submit(_small_request, subq_start, subq_end, team=team, verbose=verbose)
+            futures = {executor.submit(_small_request, subq_start, subq_end, team=team)
                     for subq_start, subq_end in date_range}
             for future in concurrent.futures.as_completed(futures):
                 dataframe_list.append(future.result())

--- a/pybaseball/statcast.py
+++ b/pybaseball/statcast.py
@@ -54,7 +54,7 @@ def _handle_request(start_dt: date, end_dt: date, step: int, verbose: bool,
     _check_warning(start_dt, end_dt)
 
     if verbose:
-        print("This is a large query, it may take a moment to complete\n", flush=True)
+        print("This is a large query, it may take a moment to complete", flush=True)
 
     dataframe_list = []
     date_range = list(statcast_date_range(start_dt, end_dt, step, verbose))

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,8 @@ setup(
                       'pygithub>=1.51',
                       'altair>=4.0.0',
                       'scipy>=1.4.0',
-                      'matplotlib>=2.0.0'
+                      'matplotlib>=2.0.0',
+                      'tqdm>=4.50.0',
                       ],
 
     # List additional groups of dependencies here (e.g. development

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 # Always prefer setuptools over distutils
-from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
 from os import path
+
+from setuptools import find_packages, setup
 
 here = path.abspath(path.dirname(__file__))
 
@@ -95,6 +96,7 @@ setup(
         'test': ['pytest>=6.0.2',
                  'mypy>=0.782',
                  'pytest-cov>=2.10.1',
+                 'pytest-xdist>=2.1.0',
                  ],
     },
 

--- a/tests/pybaseball/test_statcast.py
+++ b/tests/pybaseball/test_statcast.py
@@ -3,24 +3,11 @@ from typing import Callable
 import pandas as pd
 import pytest
 
-from pybaseball.statcast import (_SC_SINGLE_GAME_REQUEST, _SC_SMALL_REQUEST, sanitize_date_range, statcast,
-                                 statcast_single_game)
+from pybaseball.statcast import _SC_SINGLE_GAME_REQUEST, statcast_single_game
 from pybaseball.utils import DATE_FORMAT
 
 # For an explanation of this type, see the note on GetDataFrameCallable in tests/pybaseball/conftest.py
 from .conftest import GetDataFrameCallable
-
-
-@pytest.fixture(name="small_request_raw")
-def _small_request_raw(get_data_file_contents: Callable[[str], str]) -> str:
-    return get_data_file_contents('small_request_raw.csv')
-
-
-@pytest.fixture(name="small_request")
-def _small_request(get_data_file_dataframe: GetDataFrameCallable) -> pd.DataFrame:
-    data = get_data_file_dataframe('small_request.csv', parse_dates=[2])
-    data[data.columns[2]].apply(pd.to_datetime, errors='ignore', format=DATE_FORMAT)
-    return data
 
 
 @pytest.fixture(name="single_game_raw")
@@ -33,31 +20,6 @@ def _single_game(get_data_file_dataframe: GetDataFrameCallable) -> pd.DataFrame:
     data = get_data_file_dataframe('single_game_request.csv', parse_dates=[2])
     data[data.columns[2]].apply(pd.to_datetime, errors='ignore', format=DATE_FORMAT)
     return data
-
-
-def test_statcast(response_get_monkeypatch: Callable, small_request_raw: str, small_request: pd.DataFrame) -> None:
-    start_dt, end_dt = sanitize_date_range(None, None)
-    response_get_monkeypatch(
-        small_request_raw.encode('UTF-8'),
-        _SC_SMALL_REQUEST.format(start_dt=start_dt, end_dt=end_dt, team='')
-    )
-
-    statcast_result = statcast().reset_index(drop=True)
-
-    pd.testing.assert_frame_equal(statcast_result, small_request, check_dtype=False)
-
-
-def test_statcast_team(response_get_monkeypatch: Callable, small_request_raw: str,
-                       small_request: pd.DataFrame) -> None:
-    start_dt, end_dt = sanitize_date_range(None, None)
-    response_get_monkeypatch(
-        small_request_raw.encode('UTF-8'),
-        _SC_SMALL_REQUEST.format(start_dt=start_dt, end_dt=end_dt, team='TB')
-    )
-
-    statcast_result = statcast(None, None, team='TB').reset_index(drop=True)
-
-    pd.testing.assert_frame_equal(statcast_result, small_request, check_dtype=False)
 
 
 def test_statcast_single_game_request(response_get_monkeypatch: Callable, single_game_raw: str,


### PR DESCRIPTION
In this PR I've done a few things:
* Create a ProcessPoolExecutor to run statcast calls in parallel
* Change the statcast split to a single day, so that if the cache is enabled, each day is cached separately for ease of data reuse for overlapping calls
* Also I added a pytest plugin to parallelize the tests. They now run much faster.

The speed effects for this are pretty dramatic. For the following code:
```python
import timeit

timeit.timeit("data = statcast('2020-08-01', '2020-10-05')", "from pybaseball import statcast", number=1)
```

We've gone from @ 108 seconds to @ 26 seconds. So roughly **4x** faster.

Also the tests have gone from @ 350 seconds to @ 140 seconds, so @ **2.5x** faster.

So there are some downsides:
* The print statements within the workers seem to disappear. Not sure what can be done about this. Since the results are now much faster, this is slightly less of an issue, but for EXTREMELY large data sets (for example 10 seasons of data), it can still take a while with no user feedback. We could perhaps give an estimate at the beginning of how long we think the call may take to set expectations ahead of time. Or maybe since each season is pretty fast, do a loop of each season serially, and data within it in parallel, giving a print as we finish each season.
* The pytest data injection/monkeypatch does not seem to work with these parallel tasks, so I've had to remove the unit testing around the statcast call. We still have integration tests for these though.