### PR TITLE
Fix plotting bug

### DIFF
--- a/pybaseball/plotting.py
+++ b/pybaseball/plotting.py
@@ -91,13 +91,14 @@ def spraychart(data, team_stadium, title='', tooltips=[], size=100,
     scatter = alt.Chart(sub_data, title=_title).mark_circle(size=size).encode(
         x=alt.X('hc_x:Q', axis=None, scale=alt.Scale(zero=True)),
         y=alt.Y('y:Q', axis=None, scale=alt.Scale(zero=True)),
-        tooltip=tooltips,
         color=alt.Color(
             color_label, legend=alt.Legend(title=legend_title)
         )
     ).transform_calculate(
         y='datum.hc_y * -1'
     )
+    if tooltips:
+        scatter = scatter.encode(tooltip=tooltips)
 
     plot = alt.layer(base, scatter).resolve_scale(color='independent')
     plot.width = width

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
                       'matplotlib>=2.0.0',
                       'fuzzywuzzy[speedup]>=0.15.0',
                       'tqdm>=4.50.0',
+                      'altair-saver'
                       ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
This PR fixes the bug reported in #172 (closes #172). The issue was the `tooltips` argument in the function. Leaving it blank outside of a Jupyter notebook resulted in vega, what Altair uses to render images, throwing an error.

This fix works locally, but since there aren't any tests (and I'm not sure what the best way to test this would be) I'd appreciate other devs checking as well. 