### PR TITLE
replace fuzzywuzzy

### DIFF
--- a/pybaseball/playerid_lookup.py
+++ b/pybaseball/playerid_lookup.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 
 import pandas as pd
 import requests
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 from . import cache
 
@@ -67,7 +67,7 @@ def get_closest_names(last: str, first: str, player_table: pd.DataFrame) -> pd.D
         player_table (pd.DataFrame): Chadwick player table including names
 
     Returns:
-        pd.DataFrame: 5 nearest matches from fuzzywuzzy.process
+        pd.DataFrame: 5 nearest matches from rapidfuzz.process
     """
     filled_df = player_table.fillna("")
     chadwick_names = filled_df["name_first"] + " " + filled_df["name_last"]

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
                       'altair>=4.0.0',
                       'scipy>=1.4.0',
                       'matplotlib>=2.0.0',
-                      'fuzzywuzzy[speedup]>=0.15.0',
+                      'rapidfuzz>=1.0.0',
                       'tqdm>=4.50.0',
                       'altair-saver'
                       ],


### PR DESCRIPTION
FuzzyWuzzy is GPL Licensed, which is incompatible with the license used by this project. This Pull Request replaces FuzzyWuzzy with [RapidFuzz](https://github.com/maxbachmann/rapidfuzz), which implements the same algorithms. It is licensed in a compatible way (MIT License) and is faster than FuzzyWuzzy. 