### PR TITLE
Remove fuzzywuzzy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ setup(
                       'altair>=4.0.0',
                       'scipy>=1.4.0',
                       'matplotlib>=2.0.0',
-                      'fuzzywuzzy[speedup]>=0.15.0',
                       'tqdm>=4.50.0',
                       'altair-saver'
                       ],

--- a/tests/integration/pybaseball/test_playerid_lookup.py
+++ b/tests/integration/pybaseball/test_playerid_lookup.py
@@ -59,4 +59,8 @@ def test_playerid_lookup_hyphenated_name() -> None:
     falefa_df = playerid_lookup("Kiner Falefa", "isiah", fuzzy=True)
     assert falefa_df["name_last"][0] == "kiner-falefa"
     assert falefa_df["name_first"][0] == "isiah"
-    
+
+def test_playerid_lookup_garbage() -> None:
+    """Test non-player string"""
+    no_match = playerid_lookup("abcxyz", "xyzabc", fuzzy=True)
+    assert len(no_match) == 5


### PR DESCRIPTION
Substitutes Python standard lib `difflib` for GPL licensed `fuzzywuzzy`. Closes https://github.com/jldbc/pybaseball/pull/177