### PR TITLE
Full team schedule

### DIFF
--- a/docs/schedule_and_record.md
+++ b/docs/schedule_and_record.md
@@ -1,8 +1,8 @@
 # Schedule and Record
 
-`schedule_and_record(season, team)`
+`schedule_and_record(season, team=None)`
 
-The schedule_and_record function returns a dataframe of a team's game-level results for a given season, including win/loss/tie result, score, attendance, and winning/losing/saving pitcher. If the season is incomplete, it will provide scheduling information for future games. 
+The schedule_and_record function returns a dataframe of a full season's game-level results or a team's full game-level results for a season, including win/loss/tie result, score, attendance, and winning/losing/saving pitcher. If the season is incomplete, it will provide scheduling information for future games. 
 
 ## Arguments
 `season:` Integer. The season for which you want a team's record data. 
@@ -15,6 +15,9 @@ Note that if a team did not exist during the year you are requesting data for, t
 
 ```python
 from pybaseball import schedule_and_record
+
+# Game-by-game results for all teams from the 2015 season
+data = schedule_and_record(2015)
 
 # Game-by-game results from the Yankees' 1927 season
 data = schedule_and_record(1927, "NYY")

--- a/pybaseball/team_results.py
+++ b/pybaseball/team_results.py
@@ -132,7 +132,6 @@ def schedule_and_record(season=None, team=None):
 
     if team is None:
         teams = get_season_teams(season)
-        print(teams)
     else:
         teams = [team]
 

--- a/pybaseball/team_results.py
+++ b/pybaseball/team_results.py
@@ -9,7 +9,6 @@ from pybaseball.utils import first_season_map, most_recent_season
 
 from . import cache
 
-# TODO: retrieve data for all teams? a full season's worth of results
 
 def get_soup(season, team):
     # get most recent year's schedule if year not specified

--- a/tests/integration/pybaseball/test_team_results.py
+++ b/tests/integration/pybaseball/test_team_results.py
@@ -26,6 +26,24 @@ def test_schedule_and_record(season: int, team: str) -> None:
     assert list(result.columns) == expected_columns
     assert len(result) > 0
 
+def test_schedule_and_record_for_all_teams() -> None:
+    result = schedule_and_record(2019)
+
+    assert result is not None
+    assert not result.empty
+
+    expected_columns = [
+        'Date', 'Tm', 'Home_Away', 'Opp', 'W/L', 'R', 'RA', 'Inn', 'W-L', 'Rank', 'GB', 'Win',
+        'Loss', 'Save', 'Time', 'D/N', 'Attendance', 'cLI', 'Streak', 'Orig. Scheduled'
+    ]
+
+    assert list(result.columns) == expected_columns
+    assert len(result) > 0
+
+def test_schedule_and_record_for_all_teams_bad_year() -> None:
+    with pytest.raises(ValueError):
+        schedule_and_record(1612)
+
 @pytest.mark.parametrize(
     "season, team", [
         (first_season_map[x] - 1, x) for x in first_season_map.keys()


### PR DESCRIPTION
Changes/Additions to team_results.py for schedule_and_record to enable it to pull a full season worth of data, not just a single team.

Allowing:
data = schedule_and_record(2017) # For all team records
data = schedule_and_record(2017, "HOU") # For Houston records

In order to get a list of all the teams that played in a season, I'm pulling data from the team_standard_batting table from  "http://www.baseball-reference.com/leagues/MLB/{season}.shtml". It's a bit of an odd place to pull the teams that played in the season, but it's one of the few places I've found that can pull a quick list of teams that played in a season without skirting baseball-reference's comment tables.

I've updated the schedule_and_record.md documentation and added tests to test for a single year and also to test the ValueError if it's unable to scrape the team data.