### PR TITLE
Fix typo in README and add latest release to the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
 
+**2.2.0 Release: March 15, 2021**
+
+## Release Notes
+
+- Cleaning up and parallelizing Statcast calls -- @TheCleric, @bdilday, and @schorrm
+
+- Statcast spin rate & spin direction -- @tpoatsy, see docs/statcast_pitcher_spin.md for more info.
+
+- Statcast Batter & Pitcher leaderboards -- @wfordh
+
+- We removed some fairly unnecessary dependencies that were causing a massive amount of dependency bloat -- @TheCleric and @bdilday.
+
+- Various test fixes -- @TheCleric
+
+- Spell-check to playerid lookup -- @tjburch and @mwisnie5
+
+- Plotting bugfix -- @andersonfrailey
+
+- Marcels Example -- @andersonfrailey
+
 **2.1.1 Hotfix: October 15, 2020**
 
 -  Fix statcast perf regression

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pybaseball
 
-## 2.2.0 Release: March 15, 2020
+## 2.2.0 Release: March 15, 2021
 
 **What's New?**
 


### PR DESCRIPTION
I noticed the README says the latest release is from last year, when it's really only from a few weeks ago. I don't want people second-guessing that this is an active repo.