### PR TITLE
Update split_stats.py

### DIFF
--- a/pybaseball/split_stats.py
+++ b/pybaseball/split_stats.py
@@ -83,7 +83,7 @@ def get_splits(playerid: str, year: Optional[int] = None, player_info: bool = Fa
     for i in range(len(comment)):
         commentsoup = bs.BeautifulSoup(comment[i], 'lxml')
         split_tables = commentsoup.find_all(
-            "div", {"class": "overthrow table_container"})
+            "div", {"class": "table_container"})
         splits = [ele for ele in split_tables]
         headings = []
         level_headings = []


### PR DESCRIPTION
Baseball-reference html has changed for split stats.

 {"class": "overthrow table_container"} is now  {"class": "table_container"}