### PR TITLE
Make parallel statcast requests optional

### DIFF
--- a/docs/statcast.md
+++ b/docs/statcast.md
@@ -1,5 +1,5 @@
 # Statcast
-`statcast(start_dt=[yesterday's date], end_dt=None, team=None)`
+`statcast(start_dt=[yesterday's date], end_dt=None, team=None, verbose=True, parallel=True)`
 
 The `statcast` function retrieves pitch-level statcast data for a given date or range or dates. 
 
@@ -12,11 +12,16 @@ The `statcast` function retrieves pitch-level statcast data for a given date or 
 
 `verbose:` Boolean, default=True. If set to True this will provide updates on query progress, if set to False it will not. 
 
+`parallel:` Boolean, default=True. Whether to parallelize HTTP requests in large queries.
+
 ### A note on data availability 
 The earliest available statcast data comes from the 2008 season when the system was first introduced to Major League Baseball. Queries before this year will not work. Further, some features were introduced after the 2008 season. Launch speed angle, for example, is only available from the 2015 season forward. 
 
 ### A note on query time
 Baseball savant limits queries to 30000 rows each. For this reason, if your request is for a period of greater than 5 days, it will be broken into two or more smaller requests. The data will still be returned to you in a single dataframe, but it will take slightly longer. 
+
+### A note on parallelization
+Large queries with requests made in parallel complete substantially faster. This option exists to accommodate compute environments where multiprocessing is disabled (e.g. some AWS Lambda environments).
 
 ## Examples of valid queries
 

--- a/pybaseball/statcast.py
+++ b/pybaseball/statcast.py
@@ -90,7 +90,7 @@ def _handle_request(start_dt: date, end_dt: date, step: int, verbose: bool,
 
 
 def statcast(start_dt: str = None, end_dt: str = None, team: str = None,
-             parallel: bool = True, verbose: bool = True) -> pd.DataFrame:
+             verbose: bool = True, parallel: bool = True) -> pd.DataFrame:
     """
     Pulls statcast play-level data from Baseball Savant for a given date range.
 

--- a/pybaseball/statcast.py
+++ b/pybaseball/statcast.py
@@ -51,7 +51,7 @@ def _check_warning(start_dt: date, end_dt: date) -> None:
 
 
 def _handle_request(start_dt: date, end_dt: date, step: int, verbose: bool,
-                    team: Optional[str] = None) -> pd.DataFrame:
+                    team: Optional[str] = None, parallel: bool = True) -> pd.DataFrame:
     """
     Fulfill the request in sensible increments.
     """
@@ -65,11 +65,16 @@ def _handle_request(start_dt: date, end_dt: date, step: int, verbose: bool,
     date_range = list(statcast_date_range(start_dt, end_dt, step, verbose))
 
     with tqdm(total=len(date_range)) as progress:
-        with concurrent.futures.ProcessPoolExecutor() as executor:
-            futures = {executor.submit(_small_request, subq_start, subq_end, team=team)
-                    for subq_start, subq_end in date_range}
-            for future in concurrent.futures.as_completed(futures):
-                dataframe_list.append(future.result())
+        if parallel:
+            with concurrent.futures.ProcessPoolExecutor() as executor:
+                futures = {executor.submit(_small_request, subq_start, subq_end, team=team)
+                        for subq_start, subq_end in date_range}
+                for future in concurrent.futures.as_completed(futures):
+                    dataframe_list.append(future.result())
+                    progress.update(1)
+        else:
+            for subq_start, subq_end in date_range:
+                dataframe_list.append(_small_request(subq_start, subq_end, team=team))
                 progress.update(1)
 
     # Concatenate all dataframes into final result set
@@ -84,7 +89,8 @@ def _handle_request(start_dt: date, end_dt: date, step: int, verbose: bool,
     return final_data
 
 
-def statcast(start_dt: str = None, end_dt: str = None, team: str = None, verbose: bool = True) -> pd.DataFrame:
+def statcast(start_dt: str = None, end_dt: str = None, team: str = None,
+             parallel: bool = True, verbose: bool = True) -> pd.DataFrame:
     """
     Pulls statcast play-level data from Baseball Savant for a given date range.
 
@@ -99,7 +105,8 @@ def statcast(start_dt: str = None, end_dt: str = None, team: str = None, verbose
 
     start_dt_date, end_dt_date = sanitize_date_range(start_dt, end_dt)
 
-    return _handle_request(start_dt_date, end_dt_date, 1, verbose=verbose, team=team)
+    return _handle_request(start_dt_date, end_dt_date, 1, verbose=verbose,
+                           team=team, parallel=parallel)
 
 
 def statcast_single_game(game_pk: Union[str, int]) -> pd.DataFrame:

--- a/pybaseball/statcast.py
+++ b/pybaseball/statcast.py
@@ -98,6 +98,8 @@ def statcast(start_dt: str = None, end_dt: str = None, team: str = None,
     start_dt: YYYY-MM-DD : the first date for which you want statcast data
     end_dt: YYYY-MM-DD : the last date for which you want statcast data
     team: optional (defaults to None) : city abbreviation of the team you want data for (e.g. SEA or BOS)
+    verbose: bool (defaults to True) : whether to print updates on query progress
+    parallel: bool (defaults to True) : whether to parallelize HTTP requests in large queries
 
     If no arguments are provided, this will return yesterday's statcast data.
     If one date is provided, it will return that date's statcast data.


### PR DESCRIPTION
Adds a `parallel` parameter to `pybaseball.statcast()`. If `False`, requests will be made sequentially rather than through a `ProcessPoolExecutor`.

The motivation for this is that I was trying to call the function in an AWS lambda function, where all multiprocessing is disabled. This might be a somewhat niche use case, so no worries if you don't want it. I didn't look into covering it in the tests, but I'm happy to.