### PR TITLE
Change beautiful soup parser to html.parser

### DIFF
--- a/pybaseball/league_batting_stats.py
+++ b/pybaseball/league_batting_stats.py
@@ -17,7 +17,7 @@ def get_soup(start_dt: date, end_dt: date) -> BeautifulSoup:
     #    return None
     url = "http://www.baseball-reference.com/leagues/daily.cgi?user_team=&bust_cache=&type=b&lastndays=7&dates=fromandto&fromandto={}.{}&level=mlb&franch=&stat=&stat_value=0".format(start_dt, end_dt)
     s = requests.get(url).content
-    return BeautifulSoup(s, "lxml")
+    return BeautifulSoup(s, "html.parser")
 
 
 def get_table(soup: BeautifulSoup) -> pd.DataFrame:


### PR DESCRIPTION
When using the batting_stats_range function, there was an error when parsing across the date '2021-06-25'. 

Changing the parser in beautiful soup from lxml to html.parser appears to solve the issue. 

Bug link: https://github.com/jldbc/pybaseball/issues/218