### PR TITLE
Scrape MLB IDs from Baseball-Reference

### DIFF
--- a/pybaseball/league_batting_stats.py
+++ b/pybaseball/league_batting_stats.py
@@ -24,12 +24,16 @@ def get_table(soup: BeautifulSoup) -> pd.DataFrame:
     table = soup.find_all('table')[0]
     data = []
     headings = [th.get_text() for th in table.find("tr").find_all("th")][1:]
+    headings.append("mlbID")
     data.append(headings)
     table_body = table.find('tbody')
     rows = table_body.find_all('tr')
     for row in rows:
         cols = row.find_all('td')
+        row_anchor = row.find("a")
+        mlbid = row_anchor["href"].split("mlb_ID=")[-1] if row_anchor else pd.NA  # ID str or nan
         cols = [ele.text.strip() for ele in cols]
+        cols.append(mlbid)
         data.append([ele for ele in cols])
     df = pd.DataFrame(data)
     df = df.rename(columns=df.iloc[0])

--- a/pybaseball/league_pitching_stats.py
+++ b/pybaseball/league_pitching_stats.py
@@ -23,12 +23,16 @@ def get_table(soup):
     table = soup.find_all('table')[0]
     data = []
     headings = [th.get_text() for th in table.find("tr").find_all("th")][1:]
+    headings.append("mlbID")
     data.append(headings)
     table_body = table.find('tbody')
     rows = table_body.find_all('tr')
     for row in rows:
         cols = row.find_all('td')
+        row_anchor = row.find("a")
+        mlbid = row_anchor["href"].split("mlb_ID=")[-1] if row_anchor else pd.NA  # ID str or nan
         cols = [ele.text.strip() for ele in cols]
+        cols.append(mlbid)
         data.append([ele for ele in cols])
     data = pd.DataFrame(data)
     data = data.rename(columns=data.iloc[0])

--- a/tests/integration/pybaseball/test_league_batting_stats.py
+++ b/tests/integration/pybaseball/test_league_batting_stats.py
@@ -10,7 +10,7 @@ def test_batting_stats_bref() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 27
+    assert len(result.columns) == 28
     assert(len(result)) == 991
 
 

--- a/tests/integration/pybaseball/test_league_pitching_stats.py
+++ b/tests/integration/pybaseball/test_league_pitching_stats.py
@@ -19,7 +19,7 @@ def test_pitching_stats_bref() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 40
+    assert len(result.columns) == 41
     assert(len(result)) == 831
 
 


### PR DESCRIPTION
## Context
Baseball-Reference player stat pages ([like this](https://www.baseball-reference.com/leagues/daily.fcgi?user_team=&bust_cache=&type=b&lastndays=7&dates=fromandto&fromandto=20190410.20190411&level=mlb&franch=&stat=&stat_value=0)) have player MLB IDs embedded in links. Scraping these IDs would be useful as `batting_stats_range` and `pitching_stats_range` return a Dataframe with Baseball-Reference player names as the only identifier but these are difficult to join on. This would grab the IDs from the links and add an `mlbID` column to the batting and pitching tables.

Example output of `pitching_stats_range`:
![image](https://user-images.githubusercontent.com/21132266/125552198-e9ac6197-0272-45b9-a944-2550f562dcbf.png)
