### PR TITLE
bugfix for truncated batting range data

### DIFF
--- a/pybaseball/league_batting_stats.py
+++ b/pybaseball/league_batting_stats.py
@@ -17,7 +17,9 @@ def get_soup(start_dt: date, end_dt: date) -> BeautifulSoup:
     #    return None
     url = "http://www.baseball-reference.com/leagues/daily.cgi?user_team=&bust_cache=&type=b&lastndays=7&dates=fromandto&fromandto={}.{}&level=mlb&franch=&stat=&stat_value=0".format(start_dt, end_dt)
     s = requests.get(url).content
-    return BeautifulSoup(s, "lxml")
+    # a workaround to avoid beautiful soup applying the wrong encoding
+    s = str(s).encode()
+    return BeautifulSoup(s, features="lxml")
 
 
 def get_table(soup: BeautifulSoup) -> pd.DataFrame:

--- a/pybaseball/league_pitching_stats.py
+++ b/pybaseball/league_pitching_stats.py
@@ -16,7 +16,9 @@ def get_soup(start_dt, end_dt):
         return None
     url = "http://www.baseball-reference.com/leagues/daily.cgi?user_team=&bust_cache=&type=p&lastndays=7&dates=fromandto&fromandto={}.{}&level=mlb&franch=&stat=&stat_value=0".format(start_dt, end_dt)
     s = requests.get(url).content
-    return BeautifulSoup(s, "lxml")
+    # a workaround to avoid beautiful soup applying the wrong encoding
+    s = str(s).encode()
+    return BeautifulSoup(s, features="lxml")
 
 
 def get_table(soup):


### PR DESCRIPTION
Forces a utf-8 encoding for baseball reference data in `batting_stats_range` and `pitching_stats_range` before applying beautiful soup parsing. This should avoid confusion in the encoding due to inconsistency between the table and the footer of the page.
Closes https://github.com/jldbc/pybaseball/issues/218