### PR TITLE
Change statcast pool from process to thread; fix TypeError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,5 @@ cython_debug/
 
 # MacOS
 .DS_Store
+
+scripts/

--- a/pybaseball/statcast.py
+++ b/pybaseball/statcast.py
@@ -66,7 +66,10 @@ def _handle_request(start_dt: date, end_dt: date, step: int, verbose: bool,
 
     with tqdm(total=len(date_range)) as progress:
         if parallel:
-            with concurrent.futures.ProcessPoolExecutor() as executor:
+            # Use ThreadPoolExecutor over ProcessPoolExecutor because ProcessPoolExecutor doesn't work with
+            # notebooks and python command line due to the fact it won't have a `__main__` module.
+            # See https://docs.python.org/3.7/library/concurrent.futures.html#processpoolexecutor
+            with concurrent.futures.ThreadPoolExecutor() as executor:
                 futures = {executor.submit(_small_request, subq_start, subq_end, team=team)
                         for subq_start, subq_end in date_range}
                 for future in concurrent.futures.as_completed(futures):

--- a/pybaseball/statcast_pitcher_spin.py
+++ b/pybaseball/statcast_pitcher_spin.py
@@ -132,7 +132,9 @@ def find_phi(df):
         np.arctan2(df['amagz'], df['amagx'])*180/np.pi,
         360 + np.arctan2(df['amagz'], df['amagx'])*180/np.pi) + 90
 
-    df['phi'] = df['phi'].round(0).astype('int64')
+    # astype(float) first to avoid a TypeError like so:
+    # TypeError: loop of ufunc does not support argument 0 of type float which has no callable rint method
+    df['phi'] = df['phi'].astype(float).round().astype('int64')
     return df
 
 


### PR DESCRIPTION
Fixes #229 by converting out ProcessPoolExecutor to a ThreadPoolExecutor. ProcessPoolExecutor is a little more picky about where it runs.

As well I was getting a TypeError in `statcast_pitcher_spin.py` when running the tests (python 3.7.9):

```
pybaseball/statcast_pitcher_spin.py:135: in find_phi
    df['phi'] = df['phi'].round(0).astype('int64')
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = 0       190.754943
1       300.794706
2        243.13629
3        288.17292
4       291.559998
           ...    
4215...5478
4216    448.531754
4217    436.495487
4218    440.636358
4219    434.056495
Name: phi, Length: 4220, dtype: object
decimals = 0, args = (), kwargs = {}

    def round(self, decimals=0, *args, **kwargs) -> Series:
        """
        Round each value in a Series to the given number of decimals.
    
        Parameters
        ----------
        decimals : int, default 0
            Number of decimal places to round to. If decimals is negative,
            it specifies the number of positions to the left of the decimal point.
        *args, **kwargs
            Additional arguments and keywords have no effect but might be
            accepted for compatibility with NumPy.
    
        Returns
        -------
        Series
            Rounded values of the Series.
    
        See Also
        --------
        numpy.around : Round values of an np.array.
        DataFrame.round : Round values of a DataFrame.
    
        Examples
        --------
        >>> s = pd.Series([0.1, 1.3, 2.7])
        >>> s.round()
        0    0.0
        1    1.0
        2    3.0
        dtype: float64
        """
        nv.validate_round(args, kwargs)
>       result = self._values.round(decimals)
E       TypeError: loop of ufunc does not support argument 0 of type float which has no callable rint method
```

So I followed the recommendation to make sure the column is cast to a float first before rounding.