### PR TITLE
Add a matrix to test on all python versions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,14 +9,21 @@ on:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        python-version:
+        - 3.6
+        - 3.7
+        - 3.8
+        - 3.9
     name: Install dependencies and test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v2.2.1
+        uses: actions/setup-python@v2
         with:
-          python-version: "3.6"
+          python-version: "${{ matrix.python-version }}"
       - name: Install dependencies
         run: make install
       - name: Run tests


### PR DESCRIPTION
Testing out a matrix that will test changes against all current python versions.

@schorrm I think this could help catch things like what I found in #231 which was a TypeError that seems to happen in 3.7+, but not previously caught in our 3.6 tests (which you can see are causing failures below in 3.7 and 3.8).

As well we may be able to easily add 3.10 when that's ready to see how our code base will fair.