### PR TITLE
Add check on result length before adding to cache

### DIFF
--- a/pybaseball/cache/cache.py
+++ b/pybaseball/cache/cache.py
@@ -56,7 +56,8 @@ class df_cache:
 
             if result is None:
                 result = func(*args, **kwargs)
-                self._safe_save_func_cache(func_data, result)
+                if len(result) > 0:
+                    self._safe_save_func_cache(func_data, result)
 
             return result
 


### PR DESCRIPTION
Small check prompted by issue #233. Skips caching in cases where the result is length 0. 

Not an exhaustive fix (e.g. if someone is staging August code and runs `statcast("2021-08-01","2021-08-31")` on August 25, they'll still have a non-zero dataframe but be missing a few days). Could consider something more sophisticated using datetime in the future, but this at least provides a little protection.