### PR TITLE
Update playerid_lookup to account for common nicknames

### DIFF
--- a/pybaseball/__init__.py
+++ b/pybaseball/__init__.py
@@ -76,7 +76,7 @@ from .lahman import pitching_post
 from .lahman import salaries
 from .lahman import schools
 from .lahman import series_post
-from .lahman import teams_core
+from .lahman import teams
 from .lahman import teams_upstream
 from .lahman import teams_franchises
 from .lahman import teams_half

--- a/tests/integration/pybaseball/test_playerid_lookup.py
+++ b/tests/integration/pybaseball/test_playerid_lookup.py
@@ -31,7 +31,7 @@ def test_playerid_lookup_phonetic_bogaerts() -> None:
     bogaerts_df = playerid_lookup("bogarts", "zander", fuzzy=True)
     assert bogaerts_df["name_last"][0] == "bogaerts"
     assert bogaerts_df["name_first"][0] == "xander"
-    
+
 def test_playerid_lookup_three_word_name() -> None:
     """Test names with three words in them"""
     # Hyun Jin Ryu
@@ -45,14 +45,14 @@ def test_playerid_lookup_abbreviated_name() -> None:
     martinez_df = playerid_lookup("martinez", "jd", fuzzy=True)
     assert martinez_df["name_last"][0] == "martinez"
     assert martinez_df["name_first"][0] == "j. d."
-    
+
 def test_playerid_lookup_name_with_jr() -> None:
     """Test names with abbreviations in them"""
     # Ronald Acuna Jr
     acuna_df = playerid_lookup("acuna jr.", "ronald", fuzzy=True)
     assert acuna_df["name_last"][0] == "acuna"
     assert acuna_df["name_first"][0] == "ronald"
-    
+
 def test_playerid_lookup_hyphenated_name() -> None:
     """Test names with abbreviations in them"""
     # Isiah Kiner-Falefa
@@ -64,3 +64,9 @@ def test_playerid_lookup_garbage() -> None:
     """Test non-player string"""
     no_match = playerid_lookup("abcxyz", "xyzabc", fuzzy=True)
     assert len(no_match) == 5
+
+def test_playerid_lookup_nickname() -> None:
+    """Test for Michael King, who appears as Mike King"""
+    king_df = playerid_lookup("King", "Michael", fuzzy=False)
+    assert king_df["name_last"][0] == "king"
+    assert king_df["name_first"][0] == "mike"


### PR DESCRIPTION
This pull request addresses issue #250 by accounting for names with common nicknames in the `playerid_lookup()` function. Previously, no data has been found when searching Yankees pitcher Michael King, but his data appeared under the name Mike King. This change accounts for that and other common nicknames -- for example somebody searching for Joe Votto would find the data for Joey Votto. I also added a test case for this in `test_playerid_lookup.py`.

Additionally, I updated `pybaseball.__init__.py` to match the changes made in pull request #251 (and that pull request should close issue #254); it was causing an ImportError for trying to `import teams_core`. The `teams()` function was replaced by `teams_core` in `__init__.py` but not in `lahman.py`, so I changed `teams_core` back to `teams` in the `__init__.py`.