### PR TITLE
Rename teams to teams_core

### DIFF
--- a/pybaseball/lahman.py
+++ b/pybaseball/lahman.py
@@ -123,7 +123,7 @@ def schools() -> pd.DataFrame:
 def series_post() -> pd.DataFrame:
     return _get_file("core/SeriesPost.csv")
 
-def teams() -> pd.DataFrame:
+def teams_core() -> pd.DataFrame:
     return _get_file("core/Teams.csv")
 
 def teams_upstream() -> pd.DataFrame:


### PR DESCRIPTION
#251 introduced a bug in `__init__.py` after updating `teams()` to `teams_core()`. This updates the call to the new `teams_core()`.

before:
```
In [1]: from pybaseball.batting_stats_range import batting_stats_range
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Input In [1], in <cell line: 1>()
----> 1 from pybaseball.league_batting_stats import batting_stats_range

File ~/Documents/github/pybaseball/pybaseball/__init__.py:79, in <module>
     77 from .lahman import schools
     78 from .lahman import series_post
---> 79 from .lahman import teams_core
     80 from .lahman import teams_upstream
     81 from .lahman import teams_franchises

ImportError: cannot import name 'teams_core' from 'pybaseball.lahman' (/Users/tburch/Documents/github/pybaseball/pybaseball/lahman.py)

```

after:
```
In [1]: from pybaseball.league_batting_stats import batting_stats_range

In [2]: quit()
```

I will note that #260 also took care of this, but it's probably preferable to continue with the `teams_core` name rather than roll back to `teams` and also segment this out to an independent PR.

My guess is this also covers issue #253.  