### PR TITLE
Use objects qualified name in caching 

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Timing test
         timeout-minutes: 2
         run: python -m scripts.statcast_timing
+      - name: Cache test
+        run: make validate-cache
       - name: Run MyPy
         run: make mypy ONLY_MODIFIED=0
         continue-on-error: true

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ mypy:
 test:
 	pytest $(TEST_RUN_AGAINST) $(TEST_FLAGS) --doctest-modules --cov=pybaseball --cov-report term-missing
 
+validate-cache: install
+	python ./scripts/validate_cache.py
+
 # The test-github-actions is here to allow any local developer to test the GitHub actions on their code
 # before pushing and creating a PR. Just install act from https://github.com/nektos/act and run
 # make test-github-actions

--- a/pybaseball/cache/func_utils.py
+++ b/pybaseball/cache/func_utils.py
@@ -9,5 +9,8 @@ def get_func_name(func: Callable) -> str:
     if '__self__' in dir(func):
         # This is a class method
         return f"{func.__getattribute__('__self__').__class__.__name__}.{func.__name__}"
+    # it's a method of an instantiated object
+    elif "__qualname__" in dir(func):
+        return func.__qualname__
 
-    return f"{func.__name__}"
+    return func.__name__

--- a/pybaseball/cache/func_utils.py
+++ b/pybaseball/cache/func_utils.py
@@ -10,7 +10,7 @@ def get_func_name(func: Callable) -> str:
         # This is a class method
         return f"{func.__getattribute__('__self__').__class__.__name__}.{func.__name__}"
     # it's a method of an instantiated object
-    elif "__qualname__" in dir(func):
+    elif "__qualname__" in dir(func) and r'<locals>' not in func.__qualname__:
         return func.__qualname__
 
     return func.__name__

--- a/pybaseball/datasources/fangraphs.py
+++ b/pybaseball/datasources/fangraphs.py
@@ -73,7 +73,6 @@ class FangraphsDataTable(ABC):
     def _validate(self, data: pd.DataFrame) -> pd.DataFrame:
         return data
 
-    @cache.df_cache()
     def fetch(self, start_season: int, end_season: Optional[int] = None, league: str = 'ALL', ind: int = 1,
               stat_columns: Union[str, List[str]] = 'ALL', qual: Optional[int] = None, split_seasons: bool = True,
               month: str = 'ALL', on_active_roster: bool = False, minimum_age: int = MIN_AGE,
@@ -172,6 +171,10 @@ class FangraphsBattingStatsTable(FangraphsDataTable):
     ROW_ID_FUNC: RowIdFunction = player_row_id_func
     ROW_ID_NAME = 'IDfg'
 
+    @cache.df_cache()
+    def fetch(self, *args, **kwargs):
+        return super().fetch(*args, **kwargs)
+
     def _postprocess(self, data: pd.DataFrame) -> pd.DataFrame:
         return self._sort(data, ["WAR", "OPS"], ascending=False)
 
@@ -182,6 +185,10 @@ class FangraphsFieldingStatsTable(FangraphsDataTable):
     ROW_ID_FUNC: RowIdFunction = player_row_id_func
     ROW_ID_NAME = 'IDfg'
 
+    @cache.df_cache()
+    def fetch(self, *args, **kwargs):
+        return super().fetch(*args, **kwargs)
+
     def _postprocess(self, data: pd.DataFrame) -> pd.DataFrame:
         return self._sort(data, ["DEF"], ascending=False)
 
@@ -190,6 +197,10 @@ class FangraphsPitchingStatsTable(FangraphsDataTable):
     DEFAULT_STAT_COLUMNS: List[FangraphsStatColumn] = FangraphsPitchingStats.ALL()
     ROW_ID_FUNC: RowIdFunction = player_row_id_func
     ROW_ID_NAME = 'IDfg'
+
+    @cache.df_cache()
+    def fetch(self, *args, **kwargs):
+        return super().fetch(*args, **kwargs)
 
     def _postprocess(self, data: pd.DataFrame) -> pd.DataFrame:
         if "WAR" in data.columns:

--- a/scripts/validate_cache.py
+++ b/scripts/validate_cache.py
@@ -1,6 +1,7 @@
 
 import sys
 import pybaseball
+import pandas as pd
 
 if __name__ == "__main__":
     season = 2020

--- a/scripts/validate_cache.py
+++ b/scripts/validate_cache.py
@@ -1,0 +1,13 @@
+
+import sys
+import pybaseball
+
+if __name__ == "__main__":
+    season = 2020
+    pybaseball.cache.enable()
+    batting = pybaseball.batting_stats(season)
+    pitching = pybaseball.pitching_stats(season)
+    columns_same = list(batting.columns) == list(pitching.columns)
+    shape_same = batting.shape == pitching.shape
+    cache_failed = columns_same and shape_same
+    sys.exit(int(cache_failed))


### PR DESCRIPTION
This adds a CI stage to illustrate the problem mentioned here https://github.com/jldbc/pybaseball/issues/267 https://github.com/jldbc/pybaseball/issues/221
namely that when the cache is enabled, the call to get the fangraphs batting and pitching stats return the same dataframe.