### PR TITLE
Add team option for statcast batter & pitcher

### DIFF
--- a/pybaseball/statcast_batter.py
+++ b/pybaseball/statcast_batter.py
@@ -8,6 +8,29 @@ from . import cache
 from .utils import sanitize_input, split_request
 
 
+def statcast_batter_team(start_dt: Optional[str] = None, end_dt: Optional[str] = None,
+                         team: Optional[str] = None) -> pd.DataFrame:
+    """
+    Pulls statcast pitch-level data from Baseball Savant for all batters, with at least one plate appearance, on a
+    given team
+
+    ARGUMENTS
+    start_dt : YYYY-MM-DD : the first date for which you want a player's statcast data
+    end_dt : YYYY-MM-DD : the final date for which you want data
+    team : STR : the 3 letter MLB team code (current teams only)
+    """
+    start_dt, end_dt, _ = sanitize_input(start_dt, end_dt, team)
+
+    # sanitize_input will guarantee these are not None
+    assert start_dt
+    assert end_dt
+    assert team
+
+    url = 'https://baseballsavant.mlb.com/statcast_search/csv?all=true&hfPT=&hfAB=&hfGT=R%7C&hfPR=&hfZ=&stadium=&hfBBL=&hfNewZones=&hfPull=&hfC=&hfSea=&hfSit=&player_type=batter&hfOuts=&opponent=&pitcher_throws=&batter_stands=&hfSA=&game_date_gt={}&game_date_lt={}&hfInfield=&team={}&position=&hfOutfield=&hfRO=&home_road=&hfFlag=&hfBBT=&metric_1=&hfInn=&min_pitches=0&min_results=0&group_by=name&sort_col=pitches&player_event_sort=api_p_release_speed&sort_order=desc&min_pas=0&type=details&'
+    df = split_request_team(start_dt, end_dt, team, url)
+    return df
+
+
 def statcast_batter(start_dt: Optional[str] = None, end_dt: Optional[str] = None, player_id: Optional[int] = None) -> pd.DataFrame:
     """
     Pulls statcast pitch-level data from Baseball Savant for a given batter.

--- a/pybaseball/statcast_pitcher.py
+++ b/pybaseball/statcast_pitcher.py
@@ -9,6 +9,29 @@ from . import cache
 from .utils import norm_pitch_code, sanitize_input, split_request
 
 
+def statcast_pitcher_team(start_dt: Optional[str] = None, end_dt: Optional[str] = None,
+                          team: Optional[str] = None) -> pd.DataFrame:
+    """
+    Pulls statcast pitch-level data from Baseball Savant for all pitchers, with at least one batter faced, on a given team.
+
+    ARGUMENTS
+    start_dt : YYYY-MM-DD : the first date for which you want a player's statcast data
+    end_dt : YYYY-MM-DD : the final date for which you want data
+    team : INT : STR : the 3 letter MLB team code (current teams only)
+    """
+    sanitize_input(start_dt, end_dt, team)
+
+    # sanitize_input will guarantee these are not None
+    assert start_dt
+    assert end_dt
+    assert team
+
+    url = 'https://baseballsavant.mlb.com/statcast_search/csv?all=true&hfPT=&hfAB=&hfGT=R%7C&hfPR=&hfZ=&stadium=&hfBBL=&hfNewZones=&hfPull=&hfC=&hfSea=&hfSit=&player_type=pitcher&hfOuts=&opponent=&pitcher_throws=&batter_stands=&hfSA=&game_date_gt={}&game_date_lt={}&hfInfield=&team={}&position=&hfOutfield=&hfRO=&home_road=&hfFlag=&hfBBT=&metric_1=&hfInn=&min_pitches=0&min_results=0&group_by=name&sort_col=pitches&player_event_sort=api_p_release_speed&sort_order=desc&min_pas=0&type=details&'
+    df = split_request_team(start_dt, end_dt, team, url)
+
+    return df
+
+
 def statcast_pitcher(start_dt: Optional[str] = None, end_dt: Optional[str] = None, player_id: Optional[int] = None) -> pd.DataFrame:
     """
     Pulls statcast pitch-level data from Baseball Savant for a given pitcher.

--- a/pybaseball/utils.py
+++ b/pybaseball/utils.py
@@ -289,6 +289,32 @@ def split_request(start_dt: str, end_dt: str, player_id: int, url: str) -> pd.Da
 		current_dt = next_dt + timedelta(days=1)
 	return pd.concat(results)
 
+@cache.df_cache()
+def split_request_team(start_dt: str, end_dt: str, team: str, url: str) -> pd.DataFrame:
+    """
+	Splits Statcast queries to avoid request timeouts
+	"""
+    current_dt = datetime.strptime(start_dt, '%Y-%m-%d')
+    end_dt_datetime = datetime.strptime(end_dt, '%Y-%m-%d')
+    results = []  # list to hold data as it is returned
+    team_id_str = str(team)
+    print('Gathering Player Data')
+    # break query into multiple requests
+    while current_dt <= end_dt_datetime:
+        remaining = end_dt_datetime - current_dt
+        # increment date ranges by at most 60 days
+        delta = min(remaining, timedelta(days=2190))
+        next_dt = current_dt + delta
+        start_str = current_dt.strftime('%Y-%m-%d')
+        end_str = next_dt.strftime('%Y-%m-%d')
+        # retrieve data
+        data = requests.get(url.format(start_str, end_str, team_id_str))
+        df = pd.read_csv(io.StringIO(data.text))
+        # add data to list and increment current dates
+        results.append(df)
+        current_dt = next_dt + timedelta(days=1)
+    return pd.concat(results)
+
 
 def get_zip_file(url: str) -> zipfile.ZipFile:
 	"""


### PR DESCRIPTION
Add split_request_team() to utils.py, similar to split_request() but changed the player_id parameter to the 3 character team id.  Added this to not break any existing functionality with split_request() in statcast_batter.py and statcast_pitcher.py.  

Added statcast_batter_team() to statcast_batter.py to pull in all batters for a specified team during the time range.  Similar to statcast_batter() but changed the player_id parameter to the 3 character team id.

Added statcast_pitcher_team() to statcast_pitcher.py to pull in all pitchers for a specified team during the time range.  Similar to statcast_batter() but changed the player_id parameter to the 3 character team id.