### PR TITLE
Sanitize whitespace in column names from statcast calls

### DIFF
--- a/pybaseball/statcast_batter.py
+++ b/pybaseball/statcast_batter.py
@@ -5,7 +5,7 @@ import pandas as pd
 import requests
 
 from . import cache
-from .utils import sanitize_input, split_request
+from .utils import sanitize_input, split_request, sanitize_statcast_columns
 
 
 def statcast_batter(start_dt: Optional[str] = None, end_dt: Optional[str] = None, player_id: Optional[int] = None) -> pd.DataFrame:
@@ -33,6 +33,7 @@ def statcast_batter_exitvelo_barrels(year: int, minBBE: Union[int, str] = "q") -
     url = f"https://baseballsavant.mlb.com/leaderboard/statcast?type=batter&year={year}&position=&team=&min={minBBE}&csv=true"
     res = requests.get(url, timeout=None).content
     data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = sanitize_statcast_columns(data)
     return data
 
 @cache.df_cache()
@@ -40,6 +41,7 @@ def statcast_batter_expected_stats(year: int, minPA: Union[int, str] = "q") -> p
     url = f"https://baseballsavant.mlb.com/leaderboard/expected_statistics?type=batter&year={year}&position=&team=&min={minPA}&csv=true"
     res = requests.get(url, timeout=None).content
     data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = sanitize_statcast_columns(data)
     return data
 
 @cache.df_cache()
@@ -55,4 +57,5 @@ def statcast_batter_pitch_arsenal(year: int, minPA: int = 25) -> pd.DataFrame:
     url = f"https://baseballsavant.mlb.com/leaderboard/pitch-arsenal-stats?type=batter&pitchType=&year={year}&team=&min={minPA}&csv=true"
     res = requests.get(url, timeout=None).content
     data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = sanitize_statcast_columns(data)
     return data

--- a/pybaseball/statcast_fielding.py
+++ b/pybaseball/statcast_fielding.py
@@ -5,7 +5,7 @@ import pandas as pd
 import requests
 
 from . import cache
-from .utils import norm_positions
+from .utils import norm_positions, sanitize_statcast_columns
 
 @cache.df_cache()
 def statcast_outs_above_average(year: int, pos: Union[int, str], min_att: Union[int, str] = "q") -> pd.DataFrame:
@@ -16,6 +16,7 @@ def statcast_outs_above_average(year: int, pos: Union[int, str], min_att: Union[
 	url = f"https://baseballsavant.mlb.com/leaderboard/outs_above_average?type=Fielder&year={year}&team=&range=year&min={min_att}&pos={pos}&roles=&viz=show&csv=true"
 	res = requests.get(url, timeout=None).content
 	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+	data = sanitize_statcast_columns(data)
 	return data
 
 @cache.df_cache()
@@ -23,6 +24,7 @@ def statcast_outfield_directional_oaa(year: int, min_opp: Union[int, str] = "q")
 	url = f"https://baseballsavant.mlb.com/directional_outs_above_average?year={year}&min={min_opp}&team=&csv=true"
 	res = requests.get(url, timeout=None).content
 	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+	data = sanitize_statcast_columns(data)
 	return data
 
 @cache.df_cache()
@@ -30,6 +32,7 @@ def statcast_outfield_catch_prob(year: int, min_opp: Union[int, str] = "q") -> p
 	url = f"https://baseballsavant.mlb.com/leaderboard/catch_probability?type=player&min={min_opp}&year={year}&total=&csv=true"
 	res = requests.get(url, timeout=None).content
 	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+	data = sanitize_statcast_columns(data)
 	return data
 
 @cache.df_cache()
@@ -37,6 +40,7 @@ def statcast_outfielder_jump(year: int, min_att: Union[int, str] = "q") -> pd.Da
 	url = f"https://baseballsavant.mlb.com/leaderboard/outfield_jump?year={year}&min={min_att}&csv=true"
 	res = requests.get(url, timeout=None).content
 	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+	data = sanitize_statcast_columns(data)
 	return data
 
 @cache.df_cache()
@@ -52,6 +56,7 @@ def statcast_catcher_framing(year: int, min_called_p: Union[int, str] = "q") -> 
 	url = f"https://baseballsavant.mlb.com/catcher_framing?year={year}&team=&min={min_called_p}&sort=4,1&csv=true"
 	res = requests.get(url, timeout=None).content
 	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+	data = sanitize_statcast_columns(data)
 	# CSV includes league average player, which we drop from the result
 	return data.loc[data.last_name.notna()].reset_index(drop=True)	
 

--- a/pybaseball/statcast_pitcher.py
+++ b/pybaseball/statcast_pitcher.py
@@ -6,7 +6,7 @@ import pandas as pd
 import requests
 
 from . import cache
-from .utils import norm_pitch_code, sanitize_input, split_request
+from .utils import norm_pitch_code, sanitize_input, split_request, sanitize_statcast_columns
 
 
 def statcast_pitcher(start_dt: Optional[str] = None, end_dt: Optional[str] = None, player_id: Optional[int] = None) -> pd.DataFrame:
@@ -35,6 +35,7 @@ def statcast_pitcher_exitvelo_barrels(year: int, minBBE: Union[int, str] = "q") 
     url = f"https://baseballsavant.mlb.com/leaderboard/statcast?type=pitcher&year={year}&position=&team=&min={minBBE}&csv=true"
     res = requests.get(url, timeout=None).content
     data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = sanitize_statcast_columns(data)
     return data
 
 @cache.df_cache()
@@ -42,6 +43,7 @@ def statcast_pitcher_expected_stats(year: int, minPA: Union[int, str] = "q") -> 
     url = f"https://baseballsavant.mlb.com/leaderboard/expected_statistics?type=pitcher&year={year}&position=&team=&min={minPA}&csv=true"
     res = requests.get(url, timeout=None).content
     data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = sanitize_statcast_columns(data)
     return data
 
 @cache.df_cache()
@@ -52,6 +54,7 @@ def statcast_pitcher_pitch_arsenal(year: int, minP: int = 250, arsenal_type: str
     url = f"https://baseballsavant.mlb.com/leaderboard/pitch-arsenals?year={year}&min={minP}&type={arsenal_type}&hand=&csv=true"
     res = requests.get(url, timeout=None).content
     data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = sanitize_statcast_columns(data)
     return data
 
 @cache.df_cache()
@@ -60,6 +63,7 @@ def statcast_pitcher_arsenal_stats(year: int, minPA: int = 25) -> pd.DataFrame:
     url = f"https://baseballsavant.mlb.com/leaderboard/pitch-arsenal-stats?type=pitcher&pitchType=&year={year}&team=&min={minPA}&csv=true"
     res = requests.get(url, timeout=None).content
     data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = sanitize_statcast_columns(data)
     return data
 
 @cache.df_cache()
@@ -68,6 +72,7 @@ def statcast_pitcher_pitch_movement(year: int, minP: Union[int, str] = "q", pitc
     url = f"https://baseballsavant.mlb.com/leaderboard/pitch-movement?year={year}&team=&min={minP}&pitch_type={pitch_type}&hand=&x=pitcher_break_x_hidden&z=pitcher_break_z_hidden&csv=true"
     res = requests.get(url, timeout=None).content
     data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = sanitize_statcast_columns(data)
     return data
 
 @cache.df_cache()
@@ -98,6 +103,7 @@ def statcast_pitcher_active_spin(year: int, minP: int = 250, _type: str = 'spin-
     if _type == 'spin-based' and (data is None or data.empty):
         return statcast_pitcher_active_spin(year, minP, 'observed')
 
+    data = sanitize_statcast_columns(data)
     return data
 
 @cache.df_cache()
@@ -116,4 +122,5 @@ def statcast_pitcher_spin_dir_comp(year: int, pitch_a: str = "FF", pitch_b: str 
     url = f"https://baseballsavant.mlb.com/leaderboard/spin-direction-comparison?year={year}&type={pitch_a} / {pitch_b}&min={minP}&team=&pov={pov}&sort=11&sortDir=asc&csv=true"
     res = requests.get(url, timeout=None).content
     data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = sanitize_statcast_columns(data)
     return data    

--- a/pybaseball/statcast_running.py
+++ b/pybaseball/statcast_running.py
@@ -5,12 +5,14 @@ import pandas as pd
 import requests
 
 from . import cache
+from .utils import sanitize_statcast_columns
 
 @cache.df_cache()
 def statcast_sprint_speed(year: int, min_opp: int = 10) -> pd.DataFrame:
 	url = f"https://baseballsavant.mlb.com/leaderboard/sprint_speed?year={year}&position=&team=&min={min_opp}&csv=true"
 	res = requests.get(url, timeout=None).content
 	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+	data = sanitize_statcast_columns(data)
 	return data
 
 @cache.df_cache()
@@ -19,5 +21,6 @@ def statcast_running_splits(year: int, min_opp: int = 5, raw_splits: bool = True
 	url = f"https://baseballsavant.mlb.com/running_splits?type={split_type}&bats=&year={year}&position=&team=&min={min_opp}&csv=true"
 	res = requests.get(url, timeout=None).content
 	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+	data = sanitize_statcast_columns(data)
 	return data
 

--- a/pybaseball/utils.py
+++ b/pybaseball/utils.py
@@ -218,6 +218,15 @@ def statcast_date_range(start: date, stop: date, step: int, verbose: bool = True
 		low += timedelta(days=step)
 
 
+def sanitize_statcast_columns(df: pd.DataFrame) -> pd.DataFrame:
+	'''
+	Creates uniform structure in Statcast column names
+	Removes leading whitespace in column names
+	'''
+	df.columns = df.columns.str.strip()
+	return df
+
+
 def sanitize_date_range(start_dt: Optional[str], end_dt: Optional[str]) -> Tuple[date, date]:
 	# If no dates are supplied, assume they want yesterday's data
 	# send a warning in case they wanted to specify

--- a/tests/integration/pybaseball/test_statcast_batter.py
+++ b/tests/integration/pybaseball/test_statcast_batter.py
@@ -18,7 +18,7 @@ def test_statcast_batter_exitvelo_barrels() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 19
+    assert len(result.columns) == 18
     assert len(result) > 0
     assert len(result[result['attempts'] < min_bbe]) == 0
 

--- a/tests/integration/pybaseball/test_statcast_pitcher.py
+++ b/tests/integration/pybaseball/test_statcast_pitcher.py
@@ -31,7 +31,7 @@ def test_statcast_pitcher_exitvelo_barrels() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 19
+    assert len(result.columns) == 18
     assert len(result) > 0
     assert len(result[result['attempts'] < min_bbe]) == 0
 


### PR DESCRIPTION
This addresses #279, in which there's a whitespace in `first_name`. The issue was flagged for `statcast_batter_exitvelo_barrels`, however it permeated to most the statcast calls. I implemented an effectively one-line solution in utils that strips any whitespace from the column names of the statcast calls, and imported the new function and used where needed.