### PR TITLE
Statcast Arm Strength function

### DIFF
--- a/docs/statcast_fielding.md
+++ b/docs/statcast_fielding.md
@@ -126,3 +126,36 @@ data = statcast_catcher_framing(2019)
 # Catchers with at least 500 called pitches from 2019
 data = statcast_catcher_framing(2019, min_called_p = 500)
 ```
+
+# Statcast Fielding Arm Strength
+`statcast_arm_strength(year: int = 2022, min_throws: int = 100, pos: Union[int, str] = "")`
+
+This function retrieves the arm strength results for the given year, position, and minimum throws. It provides their overall average velocity on "competitive" throws, maximum velocity, number of "competitive" throws, and a breakdown by position.
+
+Per [Statcast](https://baseballsavant.mlb.com/leaderboard/arm-strength): 
+> Given that there is no rulebook definition of "a throw where the player is trying hard," and many non-competitive lobs are captured, we have elected to take the average of the top portion of a player's throws. Since the demands of each position grouping are different, the averages and qualifiers are different as well.
+>
+>    - 1B -- average of top 1% of throws -- minimum 100 throws to qualify
+>    - 2B/SS/3B -- average of top 5% of throws -- minimum 75 throws to qualify
+>    - OF -- average of top 10% of throws -- minimum 50 throws to qualify
+
+
+## Arguments
+`year:` The year for which you wish to retrieve arm strength data. Only goes back to 2020. Format: YYYY.
+`min_throws:` The minimum number of throws.
+`position:` The position for which you wish to retrieve arm strength data. It is available for all non-pitching and catching positions, as well as outfielders as a group and non-first basemen infielders. You may request the infield data with "if" as the position, though on Statcast it is under "2B/SS/3B".
+
+
+## Examples of Valid Queries
+```python
+from pybaseball import statcast_arm_strength
+
+# All qualified fielders from 2021
+data = statcast_arm_strength(2021)
+
+# Fielders with at least 500 throws from 2021
+data = statcast_arm_strength(2021, min_throws = 500)
+
+# All qualified infielders from 2021
+data = statcast_arm_strength(2021, pos="if")
+```

--- a/pybaseball/statcast_fielding.py
+++ b/pybaseball/statcast_fielding.py
@@ -55,3 +55,18 @@ def statcast_catcher_framing(year: int, min_called_p: Union[int, str] = "q") -> 
 	# CSV includes league average player, which we drop from the result
 	return data.loc[data.last_name.notna()].reset_index(drop=True)	
 
+@cache.df_cache()
+def statcast_arm_strength(year: int, pos: Union[int, str], min_throws: int = 100):
+	# want the pos as a "code" not a name or number
+	pos = norm_positions(pos, to_word=False, to_number=False)
+	# The 2B/SS/3B option uses "inf" instead of "if" as an abbreviation for
+	# "infield" for some reason
+	if pos == "if":
+		pos = "inf"
+	if pos == "2":
+		raise ValueError("This particular leaderboard does not include catchers!")
+	url = f"https://baseballsavant.mlb.com/leaderboard/arm-strength?type={is_player}&year={year}&minThrows={min_throws}&pos=arm_{pos}&team=&csv=true"
+	res = requests.get(url, timeout=None).content
+	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+	return data
+

--- a/pybaseball/utils.py
+++ b/pybaseball/utils.py
@@ -357,7 +357,7 @@ def norm_pitch_code(pitch: str, to_word: bool = False) -> str:
 		raise ValueError(f'{pitch} is not a valid pitch!')
 	return normed
 
-def norm_positions(pos: Union[int, str], to_word: bool = False, to_number: bool = True, to_code: bool = False) -> str:
+def norm_positions(pos: Union[int, str], to_word: bool = False, to_number: bool = True) -> str:
 	pos_str = str(pos)
 	normed: Optional[str] = None
 	if pos_str in pos_code_to_numbers_map.values():

--- a/pybaseball/utils.py
+++ b/pybaseball/utils.py
@@ -357,7 +357,7 @@ def norm_pitch_code(pitch: str, to_word: bool = False) -> str:
 		raise ValueError(f'{pitch} is not a valid pitch!')
 	return normed
 
-def norm_positions(pos: Union[int, str], to_word: bool = False, to_number: bool = True) -> str:
+def norm_positions(pos: Union[int, str], to_word: bool = False, to_number: bool = True, to_code: bool = False) -> str:
 	pos_str = str(pos)
 	normed: Optional[str] = None
 	if pos_str in pos_code_to_numbers_map.values():

--- a/tests/integration/pybaseball/test_statcast_fielding.py
+++ b/tests/integration/pybaseball/test_statcast_fielding.py
@@ -6,7 +6,8 @@ from pybaseball.statcast_fielding import (
 	statcast_outfield_catch_prob,
 	statcast_outfielder_jump,
 	statcast_catcher_poptime,
-	statcast_catcher_framing
+	statcast_catcher_framing,
+	statcast_arm_strength
 )
 
 def test_statcast_outs_above_average() -> None:
@@ -75,4 +76,16 @@ def test_statcast_catcher_framing() -> None:
 	assert len(result.columns) == 15
 	assert len(result) > 0
 	assert len(result.loc[result.n_called_pitches < min_called_p]) == 0
+
+def test_statcast_arm_strength() -> None:
+	min_throws = 100
+	result: pd.DataFrame = statcast_arm_strength(2021, min_throws)
+
+	assert result is not None
+	assert not result.empty
+
+	assert len(result.columns) == 26
+	assert len(result) > 0
+	assert len(result.loc[result.total_throws < min_throws]) == 0 
+
 


### PR DESCRIPTION
Function for pulling data from Statcast's new arm strength leaderboard. Everything ran with how I tested locally. I kept with how I did the other functions and left out any ability to switch to the team rollups that are possible on the actual site. There's also a weird thing where the infield (2B/SS/3B) group is labeled as "inf" in the URL instead of "if" for some reason, but that seems like another Statcast oddity. Happy to handle it another way. 