### PR TITLE
No available build of Python 3.6 for ubuntu-latest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
         - 3.8
         - 3.9
     name: Install dependencies and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python


### PR DESCRIPTION
Editing the ubuntu version to 20.04 since there are no available build of Python 3.6 for the latest Ubuntu version.