### PR TITLE
Toggle low_memory flag in playerid_lookup

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -44,12 +44,13 @@ git checkout -b my-awesome-new-feature
 4. Run setup.py (strongly recommend in a virtualenv)
 
 ```
-pip install -e .
+pip install -e '.[test]'
 ```
+
 
 5. Make your changes
 
-6. Run the test suite. From the top level `pybaseball` directory run:
+6. Run the test suite. From the top level `tests` directory run:
 
 ```
 pytest

--- a/pybaseball/playerid_lookup.py
+++ b/pybaseball/playerid_lookup.py
@@ -30,7 +30,7 @@ def _extract_people_files(zip_archive: zipfile.ZipFile) -> Iterable[zipfile.ZipI
 
 def _extract_people_table(zip_archive: zipfile.ZipFile) -> pd.DataFrame:
     dfs = map(
-        lambda zip_info: pd.read_csv(io.BytesIO(zip_archive.read(zip_info.filename))),
+        lambda zip_info: pd.read_csv(io.BytesIO(zip_archive.read(zip_info.filename)), low_memory=False),
         _extract_people_files(zip_archive),
     )
     return pd.concat(dfs, axis=0)


### PR DESCRIPTION
 * Set low_memory flag to False when reading player_id csv to avoid pandas mixed type dtype warnings.
 * Also tweaked some of the instructions in the Contributing document, presumably those instructions were a little bit dated?

Closes #319 