### PR TITLE
Change assumed end of season date from November 1 to November 30

### DIFF
--- a/pybaseball/league_batting_stats.py
+++ b/pybaseball/league_batting_stats.py
@@ -82,7 +82,7 @@ def batting_stats_bref(season: Optional[int] = None) -> pd.DataFrame:
     if season is None:
         season = most_recent_season()
     start_dt = f'{season}-03-01' #opening day is always late march or early april
-    end_dt = f'{season}-11-01' #season is definitely over by November
+    end_dt = f'{season}-11-30' #postseason is definitely over by end of November
     return batting_stats_range(start_dt, end_dt)
 
 

--- a/pybaseball/league_pitching_stats.py
+++ b/pybaseball/league_pitching_stats.py
@@ -87,7 +87,7 @@ def pitching_stats_bref(season: Optional[int]=None) -> pd.DataFrame:
         season = most_recent_season()
     str_season = str(season)
     start_dt = str_season + '-03-01' #opening day is always late march or early april
-    end_dt = str_season + '-11-01' #season is definitely over by November
+    end_dt = str_season + '-11-30' #postseason is definitely over by end of November
     return(pitching_stats_range(start_dt, end_dt))
 
 

--- a/tests/pybaseball/test_league_batting_stats.py
+++ b/tests/pybaseball/test_league_batting_stats.py
@@ -18,4 +18,4 @@ def test_batting_stats_bref_none() -> None:
     with patch('pybaseball.league_batting_stats.batting_stats_range', batting_stats_range_mock):
         league_batting_stats.batting_stats_bref(None)
 
-    batting_stats_range_mock.assert_called_once_with(f'{this_year}-03-01', f"{this_year}-11-01")
+    batting_stats_range_mock.assert_called_once_with(f'{this_year}-03-01', f"{this_year}-11-30")

--- a/tests/pybaseball/test_league_pitching_stats.py
+++ b/tests/pybaseball/test_league_pitching_stats.py
@@ -28,4 +28,4 @@ def test_pitching_stats_bref_none() -> None:
     with patch('pybaseball.league_pitching_stats.pitching_stats_range', pitching_stats_range_mock):
         league_pitching_stats.pitching_stats_bref(None)
 
-    pitching_stats_range_mock.assert_called_once_with(f'{this_year}-03-01', f"{this_year}-11-01")
+    pitching_stats_range_mock.assert_called_once_with(f'{this_year}-03-01', f"{this_year}-11-30")


### PR DESCRIPTION
While introducing/familiarizing myself with this repo I noticed a few places where the assumed end of season was no later than November 1st. We've had a few World Series in recent memory end a few days after the 1st. I figured adjusting this to end of month would be a good first issue opportunity. 