### PR TITLE
Add function to calculate vertical approach angle for Statcast Dataframes

### DIFF
--- a/docs/statcast_utils.md
+++ b/docs/statcast_utils.md
@@ -2,7 +2,7 @@
 
 Utility functions for additional calculations on StatCast DataFrames. Located in `pybaseball/datahelpers/statcast_utils.py
 
-## Functions
+## Add Spray Angle
 
 `add_spray_angle(df: pd.DataFrame,  adjusted: Optional[bool] = False)`
 
@@ -20,7 +20,7 @@ df (pd.DataFrame): StatCast pd.DataFrame (retrieved through statcast, statcast_b
 
 The following code:
 
-```
+```python
 from pybaseball.datahelpers.statcast_utils import add_spray_angle
 from pybaseball import statcast
 
@@ -63,3 +63,55 @@ Shown for 2018 data:
 
 ![](images/spray_angle_hists.png)
 
+
+## Vertical Approach Angle
+`add_vertical_approach_angle(df: pd.DataFrame)`
+
+Adds a column called "vaa" with the vertical approach angle of each pitch to a StatCast DataFrame
+    
+- Vertical approach angle is the angle, in degrees, at which the ball crosses home plate
+    
+- Formula obtained from [this Fangraphs article](https://blogs.fangraphs.com/a-visualized-primer-on-vertical-approach-angle-vaa/)
+
+### Arguments
+
+df (pd.DataFrame): StatCast pd.DataFrame (retrieved through statcast, statcast_pitcher, etc)
+
+### Example
+
+The following code:
+
+```python
+from pybaseball.datahelpers.statcast_utils import add_vertical_approach_angle
+from pybaseball import statcast_pitcher
+
+df = statcast_pitcher('2022-01-01', '2022-12-31', 543037)
+
+# Add vertical approach angle
+df = add_vertical_approach_angle(df)
+
+print("Vertical approach angle:")
+print(df['vaa'][0:5])
+print("Average vertical approach angle by pitch type:")
+print(df.groupby(['pitch_type'])['vaa'].mean())
+```
+
+Will output these vertical approach angles:
+
+```
+Vertical approach angle:
+1   -11.867287
+2    -3.098514
+3    -2.910248
+4    -7.566446
+Name: vaa, dtype: float64
+Average vertical approach angle by pitch type:
+pitch_type
+CH   -6.660848
+FC   -5.804296
+FF   -4.584262
+KC   -9.739730
+SI   -5.865324
+SL   -7.742220
+Name: vaa, dtype: float64
+```

--- a/pybaseball/datahelpers/statcast_utils.py
+++ b/pybaseball/datahelpers/statcast_utils.py
@@ -23,3 +23,21 @@ def add_spray_angle(raw_df: pd.DataFrame, adjusted: bool = False) -> pd.DataFram
         )
         df = df.drop(["spray_angle"], axis=1)
     return df
+
+def add_vertical_approach_angle(raw_df: pd.DataFrame) -> pd.DataFrame:
+    """Adds vertical approach angle to a StatCast DataFrame
+    - Vertical approach angle is the angle, in degrees, at which the ball crosses home plate
+    Args:
+        raw_df (pd.DataFrame): StatCast pd.DataFrame (retrieved through statcast, statcast_pitcher, etc)
+    Returns:
+        pd.DataFrame: Input dataframe with vertical approach angle column appended
+    """
+
+    df = raw_df.copy()
+
+    vy_f = -1 * np.sqrt(df['vy0']**2 - (2 * df['ay'] * (50 - (17 / 12))))
+    t = (vy_f - df['vy0']) / df['ay']
+    vz_f = df['vz0'] + (df['az'] * t)
+    df['vaa'] = -1 * np.arctan(vz_f / vy_f) * (180 / np.pi)
+
+    return df

--- a/tests/pybaseball/datahelpers/test_statcast_utils.py
+++ b/tests/pybaseball/datahelpers/test_statcast_utils.py
@@ -10,6 +10,14 @@ def _unprocessed_data() -> pd.DataFrame:
     ],
     columns=['stand', 'hc_x', 'hc_y'])
 
+@pytest.fixture(name='unprocessed_vaa_data')
+def _unprocessed_vaa_data() -> pd.DataFrame:
+    return pd.DataFrame([
+        [-5.045042, -136.632241, -14.79299, 11.115757, 29.865813, -9.074346],
+        [4.235708, -131.933251, 3.388941, -5.795787, 30.314587, -16.130632]
+    ],
+    columns=['vx0', 'vy0', 'vz0', 'ax', 'ay', 'az'])
+
 def test_add_spray_angle(unprocessed_data: pd.DataFrame) -> None:
     spray_angle_df = statcast_utils.add_spray_angle(unprocessed_data)
 
@@ -32,3 +40,13 @@ def test_add_spray_angle_adjusted(unprocessed_data: pd.DataFrame) -> None:
 
     pd.testing.assert_frame_equal(spray_angle_df, expected)
 
+def test_add_vertical_approach_angle(unprocessed_vaa_data: pd.DataFrame) -> None:
+    vaa_df = statcast_utils.add_vertical_approach_angle(unprocessed_vaa_data)
+
+    expected = pd.DataFrame([
+        [-5.045042, -136.632241, -14.79299, 11.115757, 29.865813, -9.074346, -8.227591],
+        [4.235708, -131.933251, 3.388941, -5.795787, 30.314587, -16.130632, -1.346296],
+    ],
+    columns=['vx0', 'vy0', 'vz0', 'ax', 'ay', 'az','vaa'])
+
+    pd.testing.assert_frame_equal(vaa_df, expected)


### PR DESCRIPTION
I added a function that calculates vertical approach angle using the formula from this [fangraphs article](https://blogs.fangraphs.com/a-visualized-primer-on-vertical-approach-angle-vaa/) to statcast_utils.py. 