### PR TITLE
Add Negro Leagues To `FangraphsLeague`

### DIFF
--- a/docs/batting_stats.md
+++ b/docs/batting_stats.md
@@ -9,7 +9,7 @@ The `batting_stats` function returns season-level batting data from FanGraphs.
 
 `end_season:` Integer. The final season you want to retrieve data from. If omitted, the funciton will return only data from the start_season.
 
-`league:` String. Either "all" for all data, "nl" for National League, "al" for the American League, or "mnl" for all Negro League data. Defaults to "all", for returning data on all teams.
+`league:` String. Either "all" for all data, "nl" for National League, "al" for the American League, or "mnl" for all Negro League data. Defaults to "all", for returning data on all teams. See `FangraphsLeague` definition for all leagues.
 
 `qual:` Integer. Minimum number of plate appearances to be included in the results. Defaults to `None`, which is equivalent to the current Fangraphs "Qualified" PA threshold from their leaderboard. 
 

--- a/docs/batting_stats.md
+++ b/docs/batting_stats.md
@@ -9,7 +9,7 @@ The `batting_stats` function returns season-level batting data from FanGraphs.
 
 `end_season:` Integer. The final season you want to retrieve data from. If omitted, the funciton will return only data from the start_season.
 
-`league:` String. "all" for both leagues, "al" for the American League, or "nl" for the National League. Defaults to "all".
+`league:` String. Either "all" for all data, "nl" for National League, "al" for the American League, or "mnl" for all Negro League data. Defaults to "all", for returning data on all teams.
 
 `qual:` Integer. Minimum number of plate appearances to be included in the results. Defaults to `None`, which is equivalent to the current Fangraphs "Qualified" PA threshold from their leaderboard. 
 

--- a/docs/fangraphs.md
+++ b/docs/fangraphs.md
@@ -6,7 +6,7 @@
 |  ---             | ---              | ---
 | start_season     | int              | The first season to pull data for. If no end_season is passed, this is the only season returned.
 | end_season       | int              | The last season to pull data for.
-| league           | str              | League to return data for: ALL, AL, FL, NL. Default = ALL
+| league           | str              | League to return data for: ALL, AL, FL, NL, MNL (See `FangraphsLeague` for all values). Default = ALL
 | ind              | int              | DEPRECATED. ONLY FOR BACKWARDS COMPATIBILITY. USE `split_seasons` INSTEAD. <br> 1 if you want individual season-level data. <br> 0 if you want a player's aggregate data over all seasons in the query
 | stat_columns     | str or List[str] | The columns of data to return. <br> Default = ALL
 | qual             | Optional[int]    | Minimum number of plate appearances to be included. <br> If None is specified, the Fangraphs default ('y') is used. <br> Default = None

--- a/docs/pitching_stats.md
+++ b/docs/pitching_stats.md
@@ -9,7 +9,7 @@ The `pitching_stats` function returns season-level pitching data from FanGraphs.
 
 `end_season:` Integer. The final season you want to retrieve data from. If omitted, the funciton will return only data from the start_season.
 
-`league:` String. "all" for both leagues, "al" for the American League, or "nl" for the National League. Defaults to "all".
+`league:` String. Either "all" for all data, "nl" for National League, "al" for the American League, or "mnl" for all Negro League data. Defaults to "all", for returning data on all teams.
 
 `qual:` Integer. Minimum number of plate appearances to be included in the results. Defaults to `None`, which is equivalent to the current Fangraphs "Qualified" PA threshold from their leaderboard.
 

--- a/docs/pitching_stats.md
+++ b/docs/pitching_stats.md
@@ -9,7 +9,7 @@ The `pitching_stats` function returns season-level pitching data from FanGraphs.
 
 `end_season:` Integer. The final season you want to retrieve data from. If omitted, the funciton will return only data from the start_season.
 
-`league:` String. Either "all" for all data, "nl" for National League, "al" for the American League, or "mnl" for all Negro League data. Defaults to "all", for returning data on all teams.
+`league:` String. Either "all" for all data, "nl" for National League, "al" for the American League, or "mnl" for all Negro League data. Defaults to "all", for returning data on all teams. See `FangraphsLeague` definition for all leagues.
 
 `qual:` Integer. Minimum number of plate appearances to be included in the results. Defaults to `None`, which is equivalent to the current Fangraphs "Qualified" PA threshold from their leaderboard.
 

--- a/docs/team_batting.md
+++ b/docs/team_batting.md
@@ -9,7 +9,7 @@ The team_batting function returns a dataframe of team-level batting stats. This 
 
 `end_season:` Integer. The last season for which you want the league's team-level batting data. If not provided, the query will return data for only the `start_season`.  
 
-`league:` String. Either "all", "nl", or "al" for determining whether you want data from one league or both. Defaults to "all", for returning data on all teams. 
+`league:` String. Either "all" for all data, "nl" for National League, "al" for the American League, or "mnl" for all Negro League data. Defaults to "all", for returning data on all teams.
 
 `ind:` Integer. Flag for whether you want data to be returned at the individual-season or aggregate level. If `ind=1`, returns one row per team per year. If `ind=0`, the query aggregates the data so that one row of aggregate stats is provided per team. For example, `team_batting(2010, 2012, ind=1)` would return 90 rows, one for each team's 2010, 2011, and 2012 stats, while `team_batting(2010, 2012, ind=0)` would return 30 rows, one for each team's aggregate 2010-2012 batting performance.
 

--- a/docs/team_batting.md
+++ b/docs/team_batting.md
@@ -9,7 +9,7 @@ The team_batting function returns a dataframe of team-level batting stats. This 
 
 `end_season:` Integer. The last season for which you want the league's team-level batting data. If not provided, the query will return data for only the `start_season`.  
 
-`league:` String. Either "all" for all data, "nl" for National League, "al" for the American League, or "mnl" for all Negro League data. Defaults to "all", for returning data on all teams.
+`league:` String. Either "all" for all data, "nl" for National League, "al" for the American League, or "mnl" for all Negro League data. Defaults to "all", for returning data on all teams. See `FangraphsLeague` definition for all leagues.
 
 `ind:` Integer. Flag for whether you want data to be returned at the individual-season or aggregate level. If `ind=1`, returns one row per team per year. If `ind=0`, the query aggregates the data so that one row of aggregate stats is provided per team. For example, `team_batting(2010, 2012, ind=1)` would return 90 rows, one for each team's 2010, 2011, and 2012 stats, while `team_batting(2010, 2012, ind=0)` would return 30 rows, one for each team's aggregate 2010-2012 batting performance.
 

--- a/docs/team_fielding.md
+++ b/docs/team_fielding.md
@@ -9,7 +9,7 @@ The team_fielding function returns a dataframe of team-level fielding stats. Thi
 
 `end_season:` Integer. The last season for which you want the league's team-level fielding data. If not provided, the query will return data for only the `start_season`.  
 
-`league:` String. Either "all" for all data, "nl" for National League, "al" for the American League, or "mnl" for all Negro League data. Defaults to "all", for returning data on all teams.
+`league:` String. Either "all" for all data, "nl" for National League, "al" for the American League, or "mnl" for all Negro League data. Defaults to "all", for returning data on all teams. See `FangraphsLeague` definition for all leagues.
 
 `ind:` Integer. Flag for whether you want data to be returned at the individual-season or aggregate level. If `ind=1`, returns one row per team per year. If `ind=0`, the query aggregates the data so that one row of aggregate stats is provided per team. For example, `team_fielding(2010, 2012, ind=1)` would return 90 rows, one for each team's 2010, 2011, and 2012 stats, while `team_fielding(2010, 2012, ind=0)` would return 30 rows, one for each team's aggregate 2010-2012 fielding performance.
 

--- a/docs/team_fielding.md
+++ b/docs/team_fielding.md
@@ -9,7 +9,7 @@ The team_fielding function returns a dataframe of team-level fielding stats. Thi
 
 `end_season:` Integer. The last season for which you want the league's team-level fielding data. If not provided, the query will return data for only the `start_season`.  
 
-`league:` String. Either "all", "nl", or "al" for determining whether you want data from one league or both. Defaults to "all", for returning data on all teams. 
+`league:` String. Either "all" for all data, "nl" for National League, "al" for the American League, or "mnl" for all Negro League data. Defaults to "all", for returning data on all teams.
 
 `ind:` Integer. Flag for whether you want data to be returned at the individual-season or aggregate level. If `ind=1`, returns one row per team per year. If `ind=0`, the query aggregates the data so that one row of aggregate stats is provided per team. For example, `team_fielding(2010, 2012, ind=1)` would return 90 rows, one for each team's 2010, 2011, and 2012 stats, while `team_fielding(2010, 2012, ind=0)` would return 30 rows, one for each team's aggregate 2010-2012 fielding performance.
 

--- a/docs/team_pitching.md
+++ b/docs/team_pitching.md
@@ -9,7 +9,7 @@ The team_pitching function returns a dataframe of team-level pitching stats. Thi
 
 `end_season:` Integer. The last season for which you want the league's team-level pitching data. If not provided, the query will return data for only the start_season.  
 
-`league:` String. Either "all" for all data, "nl" for National League, "al" for the American League, or "mnl" for all Negro League data. Defaults to "all", for returning data on all teams.
+`league:` String. Either "all" for all data, "nl" for National League, "al" for the American League, or "mnl" for all Negro League data. Defaults to "all", for returning data on all teams. See `FangraphsLeague` definition for all leagues.
 
 `ind:` Integer. Flag for whether you want data to be returned at the individual-season or aggregate level. If `ind=1`, returns one row per team per year. If `ind=0`, the query aggregates the data so that one row of aggregate stats is provided per team. For example, `team_pitching(2010, 2012, ind=1)` would return 90 rows, one for each team's 2010, 2011, and 2012 stats, while `team_pitching2010, 2012, ind=0)` would return 30 rows, one for each team's aggregate 2010-2012 pitching performance.
 

--- a/docs/team_pitching.md
+++ b/docs/team_pitching.md
@@ -9,7 +9,7 @@ The team_pitching function returns a dataframe of team-level pitching stats. Thi
 
 `end_season:` Integer. The last season for which you want the league's team-level pitching data. If not provided, the query will return data for only the start_season.  
 
-`league:` String. Either "all", "nl", or "al" for determining whether you want data from one league or both. Defaults to "all", for returning data on all teams. 
+`league:` String. Either "all" for all data, "nl" for National League, "al" for the American League, or "mnl" for all Negro League data. Defaults to "all", for returning data on all teams.
 
 `ind:` Integer. Flag for whether you want data to be returned at the individual-season or aggregate level. If `ind=1`, returns one row per team per year. If `ind=0`, the query aggregates the data so that one row of aggregate stats is provided per team. For example, `team_pitching(2010, 2012, ind=1)` would return 90 rows, one for each team's 2010, 2011, and 2012 stats, while `team_pitching2010, 2012, ind=0)` would return 30 rows, one for each team's aggregate 2010-2012 pitching performance.
 

--- a/pybaseball/enums/fangraphs/league.py
+++ b/pybaseball/enums/fangraphs/league.py
@@ -9,3 +9,11 @@ class FangraphsLeague(EnumBase):
     AL  = 'al'
     FL  = 'fl'
     NL  = 'nl'
+    MNL = 'mnl' # All Negro Leagues
+    NNL = 'nnl' # Negro National League I
+    ECL = 'ecl' # Eastern Colored League
+    ANL = 'anl' # American Negro League
+    EWL = 'ewl' # East-West League
+    NSL = 'nsl' # Negro Southern League
+    NN2 = 'nn2' # Negro National League II
+    NAL = "nal" # Negro American League


### PR DESCRIPTION
Now that [Fangraphs supports negro leagues](https://blogs.fangraphs.com/negro-leagues-data-is-now-available-on-fangraphs/), we should be able to pull that data through pybaseball. New values need to be added to the `FangraphsLeague` enum otherwise an exception is thrown.