### PR TITLE
Raise threshold on statcast_timing

### DIFF
--- a/scripts/statcast_timing.py
+++ b/scripts/statcast_timing.py
@@ -3,7 +3,7 @@ import sys
 import time
 from pybaseball import statcast
 
-DEFAULT_TIME_THRESHOLD = 30
+DEFAULT_TIME_THRESHOLD = 38
 DEFAULT_START_DATE = "2018-08-01"
 DEFAULT_END_DATE = "2018-08-10"
 


### PR DESCRIPTION
Timing failing regularly, lately it's been taking ~33 seconds. Figured I'd add a 5 sec buffer from that 33 so set to 38.