### PR TITLE
Add support for custom date range searches in Fangraphs

### DIFF
--- a/docs/batting_stats.md
+++ b/docs/batting_stats.md
@@ -15,6 +15,10 @@ The `batting_stats` function returns season-level batting data from FanGraphs.
 
 `ind:` 1 or 0. Equals 1 if you want data returned at the individual season level. Equals 0 if you want aggregate data over the seasons included in the query. With `ind=1` and a query spanning the 2010 through 2015 seasons, for example, you will get each player's stats for 2010, 2011, 2012, 2013, 2014, and 2015 in a separate observation. With `ind=0`, this same query returns one row per player with their statistics aggregated over this period (either summed or averaged depending on what's appropriate).
 
+`start_date:` String. The start date of the custom date range that you are querying for. `start_season` must be equal to the year of the start date provided.
+
+`end_date:` String. The end date of the custom date range that you are querying for. If `end_season` is not set, it will be set to the year of the end date. If it is set, `end_season` must be equal to the year of the end date.
+
 Note that larger date ranges will take longer to process.
 
 ### A note on data availability 
@@ -37,5 +41,7 @@ data = batting_stats(2010, 2016)
 # retrieve aggregate player statistics from 2000 to 2016 (i.e.: who had the most home runs overall over this period?)
 data = batting_stats(2010, 2016, ind=0)
 
+# retrieve batting data from between September 3 and October 5 in 2019
+data = batting_stats(2019, start_date='2019-09-03', end_date='2019-10-05')
 
 ```

--- a/docs/batting_stats_range.md
+++ b/docs/batting_stats_range.md
@@ -4,6 +4,8 @@
 
 The `batting_stats_range` function returns batting stats from Baseball Reference, aggregated over a user-defined time range.
 
+To get batting stats data over a time range from Fangraphs, set the start_date and end_date parameters in [the batting_stats function](./batting_stats.md).
+
 ## Arguments
 `start_dt:` String. The beginning of the date range you want batting stats for. Format: "YYYY-MM-DD". 
 

--- a/docs/pitching_stats.md
+++ b/docs/pitching_stats.md
@@ -15,6 +15,10 @@ The `pitching_stats` function returns season-level pitching data from FanGraphs.
 
 `ind:` 1 or 0. Equals 1 if you want data returned at the individual season level. Equals 0 if you want aggregate data over the seasons included in the query. With `ind=1` and a query spanning the 2010 through 2015 seasons, for example, you will get each player's stats for 2010, 2011, 2012, 2013, 2014, and 2015 in a separate observation. With `ind=0`, this same query returns one row per player with their statistics aggregated over this period (either summed or averaged depending on what's appropriate).
 
+`start_date:` String. The start date of the custom date range that you are querying for. `start_season` must be equal to the year of the start date provided.
+
+`end_date:` String. The end date of the custom date range that you are querying for. If `end_season` is not set, it will be set to the year of the end date. If it is set, `end_season` must be equal to the year of the end date.
+
 Note that larger date ranges will take longer to process.
 
 ### A note on data availability 
@@ -37,5 +41,7 @@ data = pitching_stats(2010, 2016)
 # retrieve aggregate player statistics from 2000 to 2016 (i.e.: who has the most wins over this period?)
 data = pitching_stats(2010, 2016, ind=0)
 
+# retrieve pitching data from between September 3 and October 5 in 2019
+data = pitching_stats(2019, start_date='2019-09-03', end_date='2019-10-05')
 
 ```

--- a/docs/pitching_stats_range.md
+++ b/docs/pitching_stats_range.md
@@ -4,6 +4,8 @@
 
 The pitching_stats_range function returns pitching stats from Baseball Reference, aggregated over a user-defined time range.
 
+To get pitching stats data over a time range from Fangraphs, set the start_date and end_date parameters in [the pitching_stats function](./pitching_stats.md).
+
 ## Arguments
 `start_dt:` String. The beginning of the date range you want data for. Format: "YYYY-MM-DD". 
 

--- a/pybaseball/datasources/fangraphs.py
+++ b/pybaseball/datasources/fangraphs.py
@@ -128,9 +128,16 @@ class FangraphsDataTable(ABC):
         end_year = None
 
         if start_date is not None:
+            ind = 0
+
             try:
                 formattedDate = date.fromisoformat(start_date)
                 start_year = formattedDate.year
+
+                if start_year != start_season:
+                    raise ValueError(
+                        "The start_season provided must be equal to the year of the start_date provided."
+                    )
             except:
                 raise ValueError("Parameter 'start_date' must be in the format yyyy-mm-dd.")
        
@@ -138,17 +145,24 @@ class FangraphsDataTable(ABC):
             try:
                 formattedDate = date.fromisoformat(end_date)
                 end_year = formattedDate.year
+
+                if end_season is not None and end_year != end_season:
+                    raise ValueError(
+                        "The end_season provided must be equal to the year of the end_date provided."
+                    )
             except:
                 raise ValueError("Parameter 'end_date' must be in the format yyyy-mm-dd.")
 
+        if start_year is not None and end_year is not None and  end_year - start_year > 3:
+            raise ValueError(
+                "Fangraphs only provides data for custom date ranges smaller than 3 years."
+            )
+
         if start_season is None:
-            if start_year is None:
-                raise ValueError(
-                    "You need to provide at least one season to collect data for. " +
-                    "Try specifying start_season or start_season and end_season."
-                )
-            else:
-                start_season = start_year
+            raise ValueError(
+                "You need to provide at least one season to collect data for. " +
+                "Try specifying start_season or start_season and end_season."
+            )
 
         if end_season is None:
             if end_year is None:
@@ -168,7 +182,7 @@ class FangraphsDataTable(ABC):
             'qual': qual if qual is not None else 'y',
             'type': stat_list_to_str(stat_columns_enums),
             'season': end_season,
-            'month': FangraphsMonth.parse(month).value,
+            'month': 1000 if start_date is not None else FangraphsMonth.parse(month).value,
             'season1': start_season,
             'ind': ind if ind == 0 and split_seasons else int(split_seasons),
             'team':  f'{team or 0},ts' if self.TEAM_DATA else team,
@@ -176,9 +190,9 @@ class FangraphsDataTable(ABC):
             'age': f"{minimum_age},{maximum_age}",
             'filter': _filter,
             'players': players,
-            'page': f'1_{max_results}',
             'startdate': start_date,
             'enddate': end_date,
+            'page': f'1_{max_results}',
         }
 
         return self._validate(

--- a/tests/integration/pybaseball/test_batting_leaders.py
+++ b/tests/integration/pybaseball/test_batting_leaders.py
@@ -1,0 +1,47 @@
+from time import sleep
+from typing import Generator
+
+import pytest
+
+from pybaseball import batting_stats
+
+@pytest.fixture(autouse=True)
+def before_after_each() -> Generator[None, None, None]:
+    # before each test
+    yield
+    # after each test
+    sleep(6) # BBRef will throttle us if we make more than 10 calls per minute
+
+def test_batting_stats_basic() -> None:
+    result = batting_stats(2019)
+
+    assert result is not None
+    assert not result.empty
+
+    assert len(result.columns) == 320
+    assert len(result) == 135
+
+def test_batting_stats_range() -> None:
+    result = batting_stats(2019, start_date='2019-09-03', end_date='2019-10-05')
+
+    assert result is not None
+    assert not result.empty
+
+    assert len(result.columns) == 319
+    assert len(result) == 152
+
+def test_batting_stats_range_gt3yrs() -> None:
+    with pytest.raises(ValueError):
+        result = batting_stats(2015, start_date='2015-10-03', end_date='2019-10-05')
+
+def test_batting_stats_range_start_season_ne_start_date() -> None:
+    with pytest.raises(ValueError):
+        result = batting_stats(2019, start_date='2020-10-03', end_date='2021-10-05')
+
+def test_batting_stats_range_bad_formatting() -> None:
+    with pytest.raises(ValueError):
+        result = batting_stats(2023, start_date='23-04-03', end_date='23-04-05')
+
+def test_batting_stats_range_no_start_season() -> None:
+    with pytest.raises(TypeError):
+        result = batting_stats(start_date='2020-10-03', end_date='2021-10-05')

--- a/tests/integration/pybaseball/test_pitching_leaders.py
+++ b/tests/integration/pybaseball/test_pitching_leaders.py
@@ -1,0 +1,47 @@
+from time import sleep
+from typing import Generator
+
+import pytest
+
+from pybaseball import pitching_stats
+
+@pytest.fixture(autouse=True)
+def before_after_each() -> Generator[None, None, None]:
+    # before each test
+    yield
+    # after each test
+    sleep(6) # BBRef will throttle us if we make more than 10 calls per minute
+
+def test_pitching_stats_basic() -> None:
+    result = pitching_stats(2019)
+
+    assert result is not None
+    assert not result.empty
+
+    assert len(result.columns) == 334
+    assert len(result) == 61
+
+def test_pitching_stats_range() -> None:
+    result = pitching_stats(2019, start_date='2019-09-03', end_date='2019-10-05')
+
+    assert result is not None
+    assert not result.empty
+
+    assert len(result.columns) == 333
+    assert len(result) == 57
+
+def test_pitching_stats_range_gt3yrs() -> None:
+    with pytest.raises(ValueError):
+        result = pitching_stats(2015, start_date='2015-10-03', end_date='2019-10-05')
+
+def test_pitching_stats_range_start_season_ne_start_date() -> None:
+    with pytest.raises(ValueError):
+        result = pitching_stats(2019, start_date='2020-10-03', end_date='2021-10-05')
+
+def test_pitching_stats_range_bad_formatting() -> None:
+    with pytest.raises(ValueError):
+        result = pitching_stats(2023, start_date='23-04-03', end_date='23-04-05')
+
+def test_pitching_stats_range_no_start_season() -> None:
+    with pytest.raises(TypeError):
+        result = pitching_stats(start_date='2020-10-03', end_date='2021-10-05')

--- a/tests/pybaseball/test_batting_leaders.py
+++ b/tests/pybaseball/test_batting_leaders.py
@@ -26,3 +26,7 @@ def test_batting_stats(response_get_monkeypatch: Callable, sample_html: str,
     batting_stats_result = batting_stats(season).reset_index(drop=True)
 
     pd.testing.assert_frame_equal(batting_stats_result, sample_processed_result, check_dtype=False)
+
+# def test_batting_stats_range():
+#     batting_stats_result = batting_stats(start_date='2022-10-01', end_date='2022-11-05').reset_index(drop=True)
+#     print(batting_stats_result)

--- a/tests/pybaseball/test_batting_leaders.py
+++ b/tests/pybaseball/test_batting_leaders.py
@@ -26,7 +26,3 @@ def test_batting_stats(response_get_monkeypatch: Callable, sample_html: str,
     batting_stats_result = batting_stats(season).reset_index(drop=True)
 
     pd.testing.assert_frame_equal(batting_stats_result, sample_processed_result, check_dtype=False)
-
-# def test_batting_stats_range():
-#     batting_stats_result = batting_stats(start_date='2022-10-01', end_date='2022-11-05').reset_index(drop=True)
-#     print(batting_stats_result)


### PR DESCRIPTION
This change addresses #293 by adding in `start_date` and `end_date` querying options to the Fangraphs functions.

I didn't change any existing functionality in the Fangraphs function, but did make a few design choices when adding this in:
- The user still is required to enter in the `start_season` parameter-- we could have deduced this from `start_date`, but I thought it would not be a good idea to make `start_season` not required.
- If `start_date` or `end_date` doesn't matching the year of `start_season` or `end_season`, then an error is thrown, rather than fixing that mistake for the user. If `end_season` is not entered, then it is deduced from `end_date`.
- In the fangraphs UI, if we query for a range longer than 3 years, it returns data for `end_date` - 3 years until `end_date`. But I thought it would be better to throw an error in the event that the user submits a query for longer than 3 years.


Also added two new test files for these changes, as well as updated the documentation.

