### PR TITLE
Update fangraphs month enum to support 'last x' games

### DIFF
--- a/pybaseball/enums/fangraphs/month.py
+++ b/pybaseball/enums/fangraphs/month.py
@@ -3,6 +3,9 @@ from ..enum_base import EnumBase
 
 class FangraphsMonth(EnumBase):
     ALL               = 0
+    LAST_SEVEN        = 1
+    LAST_FOURTEEN     = 2
+    LAST_THIRTY       = 3
     MARCH_APRIL       = 4
     MARCH             = MARCH_APRIL
     APRIL             = MARCH_APRIL


### PR DESCRIPTION
Fangraphs allows filtering leaderboards by last seven, fourteen and thirty days by setting the month to 1, 2, or 3 respectively.

- Adds support to pybaseball to filter by these values from fangraphs