### PR TITLE
Statcast cache incomplete issue

### DIFF
--- a/pybaseball/league_pitching_stats.py
+++ b/pybaseball/league_pitching_stats.py
@@ -46,7 +46,6 @@ def get_table(soup: BeautifulSoup) -> pd.DataFrame:
     return data
 
 
-@cache.df_cache()
 def pitching_stats_range(start_dt: Optional[str]=None, end_dt: Optional[str]=None) -> pd.DataFrame:
     """
     Get all pitching stats for a set time range. This can be the past week, the
@@ -78,6 +77,8 @@ def pitching_stats_range(start_dt: Optional[str]=None, end_dt: Optional[str]=Non
     table = table.drop('', axis=1)
     return table
 
+
+@cache.df_cache()
 def pitching_stats_bref(season: Optional[int]=None) -> pd.DataFrame:
     """
     Get all pitching stats for a set season. If no argument is supplied, gives stats for
@@ -91,6 +92,7 @@ def pitching_stats_bref(season: Optional[int]=None) -> pd.DataFrame:
     return(pitching_stats_range(start_dt, end_dt))
 
 
+@cache.df_cache()
 def bwar_pitch(return_all: bool=False) -> pd.DataFrame:
     """
     Get data from war_daily_pitch table. Returns WAR, its components, and a few other useful stats.

--- a/pybaseball/statcast.py
+++ b/pybaseball/statcast.py
@@ -19,7 +19,7 @@ _SC_SMALL_REQUEST = "/statcast_search/csv?all=true&hfPT=&hfAB=&hfBBT=&hfPR=&hfZ=
 class StatcastException(Exception):
     pass
 
-@cache.df_cache(expires=365)
+
 def _small_request(start_dt: date, end_dt: date, team: Optional[str] = None) -> pd.DataFrame:
     data = statcast_ds.get_statcast_data_from_csv_url(
         _SC_SMALL_REQUEST.format(start_dt=str(start_dt), end_dt=str(end_dt), team=team if team else '')


### PR DESCRIPTION
### Related Issue
* #375 

### Description
* Cache with `statcast` function will have incorrect value and cause `cache.purge()` not work.
* Also will cause the cache has no expire time and occupied in memory.

### What cause this issue
* If `df_cache` is wrapped by another `df_cache` the parent cache will finish writing once the child cache start writing.
* Parent cache file will become invalid JSON file and cannot be parsed correctly.

### How to fix
* Remove the `df_cache` for `_small_request`