### PR TITLE
ISSUE 393 : Decoding the content into utf-8 to avoid encoding issues 

### DIFF
--- a/pybaseball/league_batting_stats.py
+++ b/pybaseball/league_batting_stats.py
@@ -20,7 +20,7 @@ def get_soup(start_dt: date, end_dt: date) -> BeautifulSoup:
     url = "http://www.baseball-reference.com/leagues/daily.cgi?user_team=&bust_cache=&type=b&lastndays=7&dates=fromandto&fromandto={}.{}&level=mlb&franch=&stat=&stat_value=0".format(start_dt, end_dt)
     s = session.get(url).content
     # a workaround to avoid beautiful soup applying the wrong encoding
-    s = str(s).encode()
+    s = s.decode('utf-8')
     return BeautifulSoup(s, features="lxml")
 
 

--- a/pybaseball/league_pitching_stats.py
+++ b/pybaseball/league_pitching_stats.py
@@ -21,7 +21,7 @@ def get_soup(start_dt: Optional[Union[date, str]], end_dt: Optional[Union[date, 
     url = "http://www.baseball-reference.com/leagues/daily.cgi?user_team=&bust_cache=&type=p&lastndays=7&dates=fromandto&fromandto={}.{}&level=mlb&franch=&stat=&stat_value=0".format(start_dt, end_dt)
     s = session.get(url).content
     # a workaround to avoid beautiful soup applying the wrong encoding
-    s = str(s).encode()
+    s = s.decode('utf-8')
     return BeautifulSoup(s, features="lxml")
 
 


### PR DESCRIPTION
The issue is that we are wrongly encoding a bytes object parsed to a string
what we need to do instead is, decode the bytes object directly. 

This commit changes that, to decoding the content directly from _**bytes**_ into utf-8

See, the results after these changes: 

https://github.com/jldbc/pybaseball/issues/393#issuecomment-1836852467