### PR TITLE
removing depricated pandas option errors="ignore" from

### DIFF
--- a/pybaseball/datahelpers/postprocessing.py
+++ b/pybaseball/datahelpers/postprocessing.py
@@ -29,12 +29,11 @@ def try_parse_dataframe(
     data_copy = data.copy()
 
     if parse_numerics:
-        data_copy = coalesce_nulls(data_copy, null_replacement)
-        data_copy = data_copy.apply(
-            pd.to_numeric,
-            errors='ignore',
-            downcast='signed'
-        ).convert_dtypes(convert_string=False)
+        data_copy = (
+            coalesce_nulls(data_copy, null_replacement)
+            .apply(pd.to_numeric, downcast="signed")
+            .convert_dtypes(convert_string=False)
+        )
 
     string_columns = [
         dtype_tuple[0] for dtype_tuple in data_copy.dtypes.items() if str(dtype_tuple[1]) in ["object", "string"]
@@ -56,8 +55,12 @@ def try_parse_dataframe(
             # the whole dataframe just tries to gobble up ints/floats as timestamps
             for date_regex, date_format in date_formats:
                 if isinstance(first_value, str) and date_regex.match(first_value):
-                    data_copy[column] = data_copy[column].apply(pd.to_datetime, errors='ignore', format=date_format)
-                    data_copy[column] = data_copy[column].convert_dtypes(convert_string=False)
+                    data_copy[column] = (
+                        data_copy[column]
+                        .apply(pd.to_datetime, format=date_format)
+                        .convert_dtypes(convert_string=False)
+                    )
+
                     break
 
     return data_copy


### PR DESCRIPTION
datahelpers/postprocessing that was raising a FutureWarning. See pandas documentation [here](https://pandas.pydata.org/docs/reference/api/pandas.to_numeric.html) too see this in pandas documentation.

with the current version of pybaseball, the code below printed a lot of these pandas future warnings for me

```python
df = pybaseball.statcast(
    start_dt="2024-04-15",
    end_dt="2024-04-21",
)
```

Screenshot of the warning in [pandas documentation](https://pandas.pydata.org/docs/reference/api/pandas.to_numeric.html)
<img width="1481" alt="Screenshot 2024-04-22 at 9 20 52 AM" src="https://github.com/jldbc/pybaseball/assets/96762808/39ba087f-2e12-4b28-bdfe-1766fb124843">
