### PR TITLE
Allow users to split player data by team

### DIFF
--- a/pybaseball/datasources/fangraphs.py
+++ b/pybaseball/datasources/fangraphs.py
@@ -75,7 +75,7 @@ class FangraphsDataTable(ABC):
 
     def fetch(self, start_season: int, end_season: Optional[int] = None, league: str = 'ALL', ind: int = 1,
               stat_columns: Union[str, List[str]] = 'ALL', qual: Optional[int] = None, split_seasons: bool = True,
-              month: str = 'ALL', on_active_roster: bool = False, minimum_age: int = MIN_AGE,
+              split_teams: bool = False, month: str = 'ALL', on_active_roster: bool = False, minimum_age: int = MIN_AGE,
               maximum_age: int = MAX_AGE, team: str = '', _filter: str = '', players: str = '',
               position: str = 'ALL', max_results: int = 1000000,) -> pd.DataFrame:
 
@@ -98,6 +98,9 @@ class FangraphsDataTable(ABC):
                                                 Default = None
         split_seasons      : bool             : True if you want individual season-level data
                                                 False if you want aggregate data over all seasons.
+                                                Default = False
+        split_teams        : bool             : True if you want individual team-level data
+                                                False if you want aggregate data over all teams.
                                                 Default = False
         month              : str              : Month to filter data by. 'ALL' to not filter by month.
                                                 Default = 'ALL'
@@ -130,6 +133,13 @@ class FangraphsDataTable(ABC):
 
         if league is None:
             raise ValueError("parameter 'league' cannot be None.")
+        
+        if self.TEAM_DATA:
+            team = f'{team or 0},ts'
+        elif split_teams:
+            team = f'{team or 0},to'
+        else:
+            team = team
 
         url_options = {
             'pos': FangraphsPositions.parse(position).value,
@@ -141,7 +151,7 @@ class FangraphsDataTable(ABC):
             'month': FangraphsMonth.parse(month).value,
             'season1': start_season,
             'ind': ind if ind == 0 and split_seasons else int(split_seasons),
-            'team':  f'{team or 0},ts' if self.TEAM_DATA else team,
+            'team': team,
             'rost': int(on_active_roster),
             'age': f"{minimum_age},{maximum_age}",
             'filter': _filter,

--- a/pybaseball/datasources/fangraphs.py
+++ b/pybaseball/datasources/fangraphs.py
@@ -98,7 +98,7 @@ class FangraphsDataTable(ABC):
                                                 Default = None
         split_seasons      : bool             : True if you want individual season-level data
                                                 False if you want aggregate data over all seasons.
-                                                Default = False
+                                                Default = True
         split_teams        : bool             : True if you want individual team-level data
                                                 False if you want aggregate data over all teams.
                                                 Default = False


### PR DESCRIPTION
This PR enable the user to get player data split by teams.

Ex:
<img width="1242" alt="Screenshot 2024-04-22 at 21 05 59" src="https://github.com/jldbc/pybaseball/assets/29528358/4f099a23-dd53-43ed-a6ab-2c37374d69a3">
<img width="1181" alt="Screenshot 2024-04-22 at 21 06 08" src="https://github.com/jldbc/pybaseball/assets/29528358/13fabe1e-d8e0-4d5b-8ca6-6b342141b19e">

This PR also makes an update to the `fetch` docstring to accurately reflect the default value.