### PR TITLE
Add QS to fangraphs get_pitching_stats

### DIFF
--- a/pybaseball/enums/fangraphs/pitching_data_enum.py
+++ b/pybaseball/enums/fangraphs/pitching_data_enum.py
@@ -454,3 +454,5 @@ class FangraphsPitchingStats(FangraphsStatsBase):
     STF_PLUS_FO                            = '389' # Stf+ FO
     LOC_PLUS_FO                            = '390' # Loc+ FO
     PIT_PLUS_FO                            = '391' # Pit+ FO
+    QS                                     = '421' # Pit+ FO
+    QUALITY_STARTS                         = QS


### PR DESCRIPTION
Issue: https://github.com/jldbc/pybaseball/issues/50

Looks like fan graphs added QS as a stat, and maybe a few more (table rows 392-420) that we could add in the future, but this PR quickly adds QS to the end of the table

Example:
```
from pybaseball.pitching_leaders import pitching_stats

t = pitching_stats(2024).reset_index(drop=True)
for col in t.columns:
    print(col, t[col][0])
```