### PR TITLE
cache serializing error

### DIFF
--- a/pybaseball/cache/cache.py
+++ b/pybaseball/cache/cache.py
@@ -1,4 +1,5 @@
 import abc
+import datetime
 import functools
 import glob
 import os
@@ -74,7 +75,22 @@ class df_cache:
             arglist = list(args)  # tuple won't come through the JSONify well
             if arglist and isinstance(arglist[0], abc.ABC):  # remove the table classes when they're self
                 arglist = arglist[1:]
-            return {'func': func_name, 'args': arglist, 'kwargs': kwargs}
+
+            arglist = [
+                (
+                    arg.isoformat()
+                    if any(
+                        map(
+                            lambda dtype: isinstance(arg, dtype),
+                            [datetime.datetime, datetime.date],
+                        )
+                    )
+                    else arg
+                )
+                for arg in arglist
+            ]
+
+            return {"func": func_name, "args": arglist, "kwargs": kwargs}
         except:  # pylint: disable=bare-except
             return {}
 


### PR DESCRIPTION
The cache writer has been writing corrupted files. The reason seems to be that statcast takes dates as args and these can't be json serialized, example,

```
>>> import json
>>> import datetime
>>> json.dumps(datetime.date.today())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.12/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type date is not JSON serializable
```

closes https://github.com/jldbc/pybaseball/issues/437