### PR TITLE
Fixing up team bref methods

### DIFF
--- a/pybaseball/team_batting.py
+++ b/pybaseball/team_batting.py
@@ -29,8 +29,12 @@ def team_batting_bref(team: str, start_season: int, end_season: Optional[int]=No
         )
     if end_season is None:
         end_season = start_season
+    elif end_season < start_season:
+        raise ValueError(
+            "You need to provide a valid end_season. end_season must be >= start_season"
+        )
 
-    url = "https://www.baseball-reference.com/teams/{}".format(team)
+    url = "https://www.baseball-reference.com/teams/{}".format(team.upper())
 
     raw_data = []
     headings: Optional[List[str]] = None

--- a/pybaseball/team_fielding.py
+++ b/pybaseball/team_fielding.py
@@ -32,8 +32,12 @@ def team_fielding_bref(team: str, start_season: int, end_season: Optional[int]=N
         )
     if end_season is None:
         end_season = start_season
+    elif end_season < start_season:
+        raise ValueError(
+            "You need to provide a valid end_season. end_season must be >= start_season"
+        )
 
-    url = "https://www.baseball-reference.com/teams/{}".format(team)
+    url = "https://www.baseball-reference.com/teams/{}".format(team.upper())
 
     raw_data = []
     headings: Optional[List[str]] = None

--- a/pybaseball/team_pitching.py
+++ b/pybaseball/team_pitching.py
@@ -29,8 +29,12 @@ def team_pitching_bref(team: str, start_season: int, end_season: Optional[int]=N
         )
     if end_season is None:
         end_season = start_season
+    elif end_season < start_season:
+        raise ValueError(
+            "You need to provide a valid end_season. end_season must be >= start_season"
+        )
 
-    url = "https://www.baseball-reference.com/teams/{}".format(team)
+    url = "https://www.baseball-reference.com/teams/{}".format(team.upper())
 
     raw_data = []
     headings: Optional[List[str]] = None


### PR DESCRIPTION
Pull request addressing the issue raised in #462 . Updating `team_pitching_bref`, `team_batting_bref`, and `team_fielding_bref` with 2 changes each:

- Use the `.upper()` method on the team abbreviation so the query will work for team abbreviations passed in regardless of case. 
- Check that the `end_season` is not < `start_season`. If it is, throw a value error. 