### PR TITLE
Improved team bref functions for error handling and robustness

### DIFF
--- a/pybaseball/team_batting.py
+++ b/pybaseball/team_batting.py
@@ -25,12 +25,16 @@ def team_batting_bref(team: str, start_season: int, end_season: Optional[int]=No
     """
     if start_season is None:
         raise ValueError(
-            "You need to provide at least one season to collect data for. Try team_batting_bref(season) or team_batting_bref(start_season, end_season)."
+            "You need to provide at least one season to collect data for. Try team_batting_bref(team, season) or team_batting_bref(team, start_season, end_season)."
         )
     if end_season is None:
         end_season = start_season
+    if end_season < start_season:
+        raise ValueError(
+            "The end_season cannot be before the start_season."
+        )
 
-    url = "https://www.baseball-reference.com/teams/{}".format(team)
+    url = "https://www.baseball-reference.com/teams/{}".format(team.upper())
 
     raw_data = []
     headings: Optional[List[str]] = None

--- a/pybaseball/team_fielding.py
+++ b/pybaseball/team_fielding.py
@@ -28,12 +28,16 @@ def team_fielding_bref(team: str, start_season: int, end_season: Optional[int]=N
     if start_season is None:
         raise ValueError(
             "You need to provide at least one season to collect data for. " +
-            "Try team_fielding_bref(season) or team_fielding_bref(start_season, end_season)."
+            "Try team_fielding_bref(team, season) or team_fielding_bref(team, start_season, end_season)."
         )
     if end_season is None:
         end_season = start_season
+    if end_season < start_season:
+        raise ValueError(
+            "The end_season cannot be before the start_season."
+        )
 
-    url = "https://www.baseball-reference.com/teams/{}".format(team)
+    url = "https://www.baseball-reference.com/teams/{}".format(team.upper())
 
     raw_data = []
     headings: Optional[List[str]] = None

--- a/pybaseball/team_pitching.py
+++ b/pybaseball/team_pitching.py
@@ -25,12 +25,16 @@ def team_pitching_bref(team: str, start_season: int, end_season: Optional[int]=N
     """
     if start_season is None:
         raise ValueError(
-            "You need to provide at least one season to collect data for. Try team_pitching_bref(season) or team_pitching_bref(start_season, end_season)."
+            "You need to provide at least one season to collect data for. Try team_pitching_bref(team, season) or team_pitching_bref(team, start_season, end_season)."
         )
     if end_season is None:
         end_season = start_season
+    if end_season < start_season:
+        raise ValueError(
+            "The end_season cannot be before the start_season."
+        )
 
-    url = "https://www.baseball-reference.com/teams/{}".format(team)
+    url = "https://www.baseball-reference.com/teams/{}".format(team.upper())
 
     raw_data = []
     headings: Optional[List[str]] = None


### PR DESCRIPTION
The following PR aims to improve the robustness of team_pitching.py, team_fielding.py, and team_batting.py.

Currently, if a user inputs a valid three letter abbreviation for a team when calling team_[fielding, batting, or pitching]_bref(), but without all letters capitalized (ex. "oak" or "OaK" instead of "OAK"), it raises the error: AttributeError: 'NoneType' object has no attribute 'find'

Additionally, there is error handling if a user does not input a start_season, but no error handling if a user inputs an invalid range (ex. end season before start season).

The following PR addresses both of these issues, raised in #462, by adding .upper() to the variable, team, and adding error handling for the season parameter range to increase the robustness of the respective function in each of the aforementioned files. It also improves the ValueError documentation for `if start_season is None` by including team as a parameter in the example calls of the function.
