### PR TITLE
fix issue 470, using curl_cffi requests library instead of requests

### DIFF
--- a/pybaseball/datasources/bref.py
+++ b/pybaseball/datasources/bref.py
@@ -2,7 +2,7 @@ import datetime
 from time import sleep
 from typing import Any, Optional
 
-import requests
+from curl_cffi import requests
 
 from ..datahelpers import singleton
 
@@ -30,6 +30,12 @@ class BRefSession(singleton.Singleton):
                 sleep(sleep_length)
 
         self.last_request = datetime.datetime.now()
+        try:
+            resp = self.session.get(url, impersonate="chrome", **kwargs)
+            resp.raise_for_status()
+            return resp
+        except requests.exceptions.RequestException as e:
+            print(f"Error: {e}")
 
-        return self.session.get(url, **kwargs)
+        return -1
                 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ setup(
                       'matplotlib>=2.0.0',
                       'tqdm>=4.50.0',
                       'attrs>=20.3.0',
+                      'curl_cffi>=0.10.0',
                       ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
usese the curl_cffi requests instead of requests.
This will help avoid cloudflare checks on requests, and impersonates the chrome request methods. 

This fixes issue 470