### PR TITLE
Fix datetime deprecation

### DIFF
--- a/pybaseball/datahelpers/postprocessing.py
+++ b/pybaseball/datahelpers/postprocessing.py
@@ -56,7 +56,7 @@ def try_parse_dataframe(
             # the whole dataframe just tries to gobble up ints/floats as timestamps
             for date_regex, date_format in date_formats:
                 if isinstance(first_value, str) and date_regex.match(first_value):
-                    data_copy[column] = data_copy[column].apply(pd.to_datetime, errors='ignore', format=date_format)
+                    data_copy[column] = data_copy[column].apply(pd.to_datetime, format=date_format)
                     data_copy[column] = data_copy[column].convert_dtypes(convert_string=False)
                     break
 

--- a/pybaseball/datahelpers/postprocessing.py
+++ b/pybaseball/datahelpers/postprocessing.py
@@ -56,7 +56,14 @@ def try_parse_dataframe(
             # the whole dataframe just tries to gobble up ints/floats as timestamps
             for date_regex, date_format in date_formats:
                 if isinstance(first_value, str) and date_regex.match(first_value):
-                    data_copy[column] = data_copy[column].apply(pd.to_datetime, format=date_format)
+
+                    def ignore_error_to_datetime(value, date_format):
+                        try:
+                            return pd.to_datetime(value, format=date_format)
+                        except:
+                            return value
+
+                    data_copy[column] = data_copy[column].apply(lambda x: ignore_error_to_datetime(x, date_format))
                     data_copy[column] = data_copy[column].convert_dtypes(convert_string=False)
                     break
 


### PR DESCRIPTION
## Fix pandas to_datetime deprecation warning

This PR removes a FutureWarning in pybaseball/datahelpers/postprocessing.py related to the use of `errors='ignore'` in pd.to_datetime, which is being deprecated.

### Changes:
- Wrapped call to df.to_datetime in a function and in a try: except: block
- Maintained the same results while removing the warning

### Testing:
- Confirmed the warning no longer appears
- Verified that date parsing still works correctly with both valid and invalid dates

### Original warning:
```
pybaseball/datahelpers/postprocessing.py:59: FutureWarning: errors='ignore' is deprecated and will raise in a future version. Use to_datetime without passing `errors` and catch exceptions explicitly instead
  data_copy[column] = data_copy[column].apply(pd.to_datetime, errors='ignore', format=date_format)
```
