### PR TITLE
Fix team_game_logs: updated table ID, filtering, and data cleanup

### DIFF
--- a/pybaseball/team_game_logs.py
+++ b/pybaseball/team_game_logs.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from bs4 import BeautifulSoup
+from io import StringIO
 
 from . import cache
 from .datasources.bref import BRefSession
@@ -13,28 +14,30 @@ def get_table(season: int, team: str, log_type: str) -> pd.DataFrame:
     t_param = "b" if log_type == "batting" else "p"
     content = session.get(_URL.format(team, t_param, season)).content
     soup = BeautifulSoup(content, "lxml")
-    table_id = "team_{}_gamelogs".format(log_type)
+    table_id = "players_standard_{}".format(log_type)
     table = soup.find("table", attrs=dict(id=table_id))
     if table is None:
         raise RuntimeError("Table with expected id not found on scraped page.")
-    data = pd.read_html(str(table))[0]
+    data = pd.read_html(StringIO(str(table)))[0]
     return data
 
 
 def postprocess(data: pd.DataFrame) -> pd.DataFrame:
-    data.drop("Rk", axis=1, inplace=True)  # drop index column
+    #print(data.columns)
+    data.drop([('Unnamed: 0_level_0', 'Rk')], axis=1, inplace=True)  # drop index column
+    data = data.iloc[:-1]
     repl_dict = {
-        "Gtm": "Game",
-        "Unnamed: 3": "Home",
+        "Gtm" : "Game",
+        "Unnamed: 3_level_1": "Home",
         "#": "NumPlayers",
         "Opp. Starter (GmeSc)": "OppStart",
         "Pitchers Used (Rest-GameScore-Dec)": "PitchersUsed"
     }
-    data.rename(repl_dict, axis=1, inplace=True)
-    data["Home"] = data["Home"].isnull()  # '@' if away, empty if home
-    data = data[data["Game"].str.match(r"\d+")]  # drop empty month rows
+    data = data.rename(columns= repl_dict).copy()
+    data[('Unnamed: 3_level_0','Home')] = data[('Unnamed: 3_level_0','Home')].isnull()  # '@' if away, empty if home
+    data = data[data[('Unnamed: 1_level_0','Game')] != 'Gtm'].copy()  # drop empty month rows
     data = data.apply(pd.to_numeric, errors="ignore")
-    data["Game"] = data["Game"].astype(int)
+    data[('Unnamed: 1_level_0','Game')] = data[('Unnamed: 1_level_0','Game')].astype(int)
     return data.reset_index(drop=True)
 
 


### PR DESCRIPTION
This PR fixes a scraping failure in team_game_logs() cause by a structural change on Baseball Reference. 

Fixes #483 

**Changes:**
- Updated column lookup to match new MultiIndex structure
- Updated table ID with 'players_standard_{}
- Added .copy to filtering to avoid warnings 
- Added StringIO to read_html to avoid deprecated passing literal to read_html 
- Updated how Rk was dropped 

Tested on: 
```python
from pybaseball import team_game_logs
df = team_game_logs(2024, "TOR")