### PR TITLE
Added Statcast Run Value, Fixed Statcast Filtering, & Updated Tests

### DIFF
--- a/pybaseball/__init__.py
+++ b/pybaseball/__init__.py
@@ -13,7 +13,8 @@ from .statcast_pitcher import (
 	statcast_pitcher_pitch_arsenal,
 	statcast_pitcher_arsenal_stats,
 	statcast_pitcher_percentile_ranks,
-	statcast_pitcher_spin_dir_comp
+	statcast_pitcher_spin_dir_comp,
+	statcast_pitcher_run_value
 )
 from .statcast_batter import (
 	statcast_batter,
@@ -21,7 +22,8 @@ from .statcast_batter import (
 	statcast_batter_expected_stats,
 	statcast_batter_percentile_ranks,
 	statcast_batter_pitch_arsenal,
-    statcast_batter_bat_tracking
+    statcast_batter_bat_tracking,
+	statcast_batter_run_value
 )
 from .statcast_running import statcast_sprint_speed, statcast_running_splits
 from .statcast_fielding import (

--- a/pybaseball/cache/cache.py
+++ b/pybaseball/cache/cache.py
@@ -7,8 +7,8 @@ from typing import Any, Callable, Dict, Optional, TypeVar, cast
 
 import pandas as pd
 
-from pybaseball.cache import cache_record, func_utils
-from pybaseball.cache.cache_config import CacheConfig, autoload_cache
+from .cache import cache_record, func_utils
+from .cache_config import CacheConfig, autoload_cache
 
 # Doing this instead of defining the types in our cache functions allows VS Code to pick up the proper type annotations
 # https://github.com/microsoft/pyright/issues/774
@@ -96,7 +96,6 @@ class df_cache:
     def _safe_load_func_cache(self, func_data: Dict) -> Optional[pd.DataFrame]:
         try:
             glob_path = os.path.join(self.cache_config.cache_directory, f'{func_data["func"]}*.cache_record.json')
-            print(glob_path)
             record_files = glob.glob(glob_path)
 
             records = [cache_record.CacheRecord(filename) for filename in record_files]

--- a/pybaseball/cache/cache.py
+++ b/pybaseball/cache/cache.py
@@ -7,8 +7,8 @@ from typing import Any, Callable, Dict, Optional, TypeVar, cast
 
 import pandas as pd
 
-from . import cache_record, func_utils
-from .cache_config import CacheConfig, autoload_cache
+from pybaseball.cache import cache_record, func_utils
+from pybaseball.cache.cache_config import CacheConfig, autoload_cache
 
 # Doing this instead of defining the types in our cache functions allows VS Code to pick up the proper type annotations
 # https://github.com/microsoft/pyright/issues/774
@@ -54,7 +54,6 @@ class df_cache:
         def _cached(*args: Any, **kwargs: Any) -> pd.DataFrame:
             func_data = self._safe_get_func_data(func, args, kwargs)
             result = self._safe_load_func_cache(func_data)
-
             if result is None:
                 result = func(*args, **kwargs)
                 if len(result) > 0:
@@ -97,7 +96,7 @@ class df_cache:
     def _safe_load_func_cache(self, func_data: Dict) -> Optional[pd.DataFrame]:
         try:
             glob_path = os.path.join(self.cache_config.cache_directory, f'{func_data["func"]}*.cache_record.json')
-
+            print(glob_path)
             record_files = glob.glob(glob_path)
 
             records = [cache_record.CacheRecord(filename) for filename in record_files]

--- a/pybaseball/cache/cache.py
+++ b/pybaseball/cache/cache.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, Optional, TypeVar, cast
 
 import pandas as pd
 
-from .cache import cache_record, func_utils
+from . import cache_record, func_utils
 from .cache_config import CacheConfig, autoload_cache
 
 # Doing this instead of defining the types in our cache functions allows VS Code to pick up the proper type annotations

--- a/pybaseball/statcast_batter.py
+++ b/pybaseball/statcast_batter.py
@@ -121,3 +121,16 @@ def statcast_batter_bat_tracking(year: int, minSwings: Union[int, str] = "q") ->
         return data
     except Exception as e:
         raise KeyError(f"URL {e} is unreachable")
+
+@cache.df_cache()
+def statcast_batter_run_value(year:int) ->pd.DataFrame():
+    try:
+        url = f"https://baseballsavant.mlb.com/leaderboard/swing-take?year={year}&team=&leverage=Neutral&group=Batter&type=All&sub_type=null&min=q&csv=True"
+        res = requests.get(url, timeout=None).content
+        data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+        data = sanitize_statcast_columns(data)
+        return data
+    except Exception as e:
+        raise KeyError(f"URL {e} is unreachable")
+"https://baseballsavant.mlb.com/leaderboard/swing-take?year={year}&team=&leverage=Neutral&group=Batter&type=All&sub_type=null&min=q&csv=True"
+"https://baseballsavant.mlb.com/leaderboard/swing-take?year={year}&team=&leverage=Neutral&group=Pitcher&type=All&sub_type=null&min=q&csv=True"

--- a/pybaseball/statcast_batter.py
+++ b/pybaseball/statcast_batter.py
@@ -8,15 +8,18 @@ from . import cache
 from .utils import sanitize_input, split_request, sanitize_statcast_columns
 
 
-def statcast_batter(start_dt: Optional[str] = None, end_dt: Optional[str] = None,
-                    player_id: Optional[int] = None) -> pd.DataFrame:
+def statcast_batter(
+    start_dt: Optional[str] = None,
+    end_dt: Optional[str] = None,
+    player_id: Optional[int] = None,
+) -> pd.DataFrame:
     """
     Pulls statcast pitch-level data from Baseball Savant for a given batter.
 
     ARGUMENTS
         start_dt : YYYY-MM-DD : the first date for which you want a player's statcast data
         end_dt : YYYY-MM-DD : the final date for which you want data
-        player_id : INT : the player's MLBAM ID. Find this by calling pybaseball.playerid_lookup(last_name, first_name), 
+        player_id : INT : the player's MLBAM ID. Find this by calling pybaseball.playerid_lookup(last_name, first_name),
             finding the correct player, and selecting their key_mlbam.
     """
     start_dt, end_dt, _ = sanitize_input(start_dt, end_dt, player_id)
@@ -26,13 +29,15 @@ def statcast_batter(start_dt: Optional[str] = None, end_dt: Optional[str] = None
     assert end_dt
     assert player_id
 
-    url = 'https://baseballsavant.mlb.com/statcast_search/csv?all=true&hfPT=&hfAB=&hfBBT=&hfPR=&hfZ=&stadium=&hfBBL=&hfNewZones=&hfGT=R%7CPO%7CS%7C=&hfSea=&hfSit=&player_type=batter&hfOuts=&opponent=&pitcher_throws=&batter_stands=&hfSA=&game_date_gt={}&game_date_lt={}&batters_lookup%5B%5D={}&team=&position=&hfRO=&home_road=&hfFlag=&metric_1=&hfInn=&min_pitches=0&min_results=0&group_by=name&sort_col=pitches&player_event_sort=h_launch_speed&sort_order=desc&min_abs=0&type=details&'
+    url = "https://baseballsavant.mlb.com/statcast_search/csv?all=true&hfPT=&hfAB=&hfBBT=&hfPR=&hfZ=&stadium=&hfBBL=&hfNewZones=&hfGT=R%7CPO%7CS%7C=&hfSea=&hfSit=&player_type=batter&hfOuts=&opponent=&pitcher_throws=&batter_stands=&hfSA=&game_date_gt={}&game_date_lt={}&batters_lookup%5B%5D={}&team=&position=&hfRO=&home_road=&hfFlag=&metric_1=&hfInn=&min_pitches=0&min_results=0&group_by=name&sort_col=pitches&player_event_sort=h_launch_speed&sort_order=desc&min_abs=0&type=details&"
     df = split_request(start_dt, end_dt, player_id, url)
     return df
 
 
 @cache.df_cache()
-def statcast_batter_exitvelo_barrels(year: int, minBBE: Union[int, str] = "q") -> pd.DataFrame:
+def statcast_batter_exitvelo_barrels(
+    year: int, minBBE: Union[int, str] = "q"
+) -> pd.DataFrame:
     """
     Retrieves batted ball data for all batters in a given year.
 
@@ -44,13 +49,15 @@ def statcast_batter_exitvelo_barrels(year: int, minBBE: Union[int, str] = "q") -
     """
     url = f"https://baseballsavant.mlb.com/leaderboard/statcast?type=batter&year={year}&position=&team=&min={minBBE}&csv=true"
     res = requests.get(url, timeout=None).content
-    data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
     data = sanitize_statcast_columns(data)
     return data
 
 
 @cache.df_cache()
-def statcast_batter_expected_stats(year: int, minPA: Union[int, str] = "q") -> pd.DataFrame:
+def statcast_batter_expected_stats(
+    year: int, minPA: Union[int, str] = "q"
+) -> pd.DataFrame:
     """
     Retrieves expected stats based on quality of batted ball contact in a given year.
 
@@ -62,7 +69,7 @@ def statcast_batter_expected_stats(year: int, minPA: Union[int, str] = "q") -> p
     try:
         url = f"https://baseballsavant.mlb.com/leaderboard/expected_statistics?type=batter&year={year}&position=&team=&filterType=pa&min={minPA}&csv=true"
         res = requests.get(url, timeout=None).content
-        data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+        data = pd.read_csv(io.StringIO(res.decode("utf-8")))
         data = sanitize_statcast_columns(data)
         return data
     except Exception as e:
@@ -80,7 +87,7 @@ def statcast_batter_percentile_ranks(year: int) -> pd.DataFrame:
     """
     url = f"https://baseballsavant.mlb.com/leaderboard/percentile-rankings?type=batter&year={year}&position=&team=&csv=true"
     res = requests.get(url, timeout=None).content
-    data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
     # URL returns a null player with player id 999999, which we want to drop
     return data.loc[data.player_name.notna()].reset_index(drop=True)
 
@@ -97,13 +104,15 @@ def statcast_batter_pitch_arsenal(year: int, minPA: int = 25) -> pd.DataFrame:
     """
     url = f"https://baseballsavant.mlb.com/leaderboard/pitch-arsenal-stats?type=batter&pitchType=&year={year}&team=&min={minPA}&csv=true"
     res = requests.get(url, timeout=None).content
-    data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
     data = sanitize_statcast_columns(data)
     return data
 
 
 @cache.df_cache()
-def statcast_batter_bat_tracking(year: int, minSwings: Union[int, str] = "q") -> pd.DataFrame:
+def statcast_batter_bat_tracking(
+    year: int, minSwings: Union[int, str] = "q"
+) -> pd.DataFrame:
     """
     Retrieves a player's bat tracking data for a given year.
 
@@ -116,21 +125,24 @@ def statcast_batter_bat_tracking(year: int, minSwings: Union[int, str] = "q") ->
     try:
         url = f"https://baseballsavant.mlb.com/leaderboard/bat-tracking/swing-path-attack-angle?dateStart={year}-01-01&dateEnd={year}-12-31&gameType=Regular&minSwings={minSwings}&minGroupSwings=1&seasonStart={year}&seasonEnd={year}&type=batter&csv=true"
         res = requests.get(url, timeout=None).content
-        data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+        data = pd.read_csv(io.StringIO(res.decode("utf-8")))
         data = sanitize_statcast_columns(data)
         return data
     except Exception as e:
         raise KeyError(f"URL {e} is unreachable")
 
+
 @cache.df_cache()
-def statcast_batter_run_value(year:int) ->pd.DataFrame():
+def statcast_batter_run_value(year: int) -> pd.DataFrame():
     try:
         url = f"https://baseballsavant.mlb.com/leaderboard/swing-take?year={year}&team=&leverage=Neutral&group=Batter&type=All&sub_type=null&min=q&csv=True"
         res = requests.get(url, timeout=None).content
-        data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+        data = pd.read_csv(io.StringIO(res.decode("utf-8")))
         data = sanitize_statcast_columns(data)
         return data
     except Exception as e:
         raise KeyError(f"URL {e} is unreachable")
+
+
 "https://baseballsavant.mlb.com/leaderboard/swing-take?year={year}&team=&leverage=Neutral&group=Batter&type=All&sub_type=null&min=q&csv=True"
 "https://baseballsavant.mlb.com/leaderboard/swing-take?year={year}&team=&leverage=Neutral&group=Pitcher&type=All&sub_type=null&min=q&csv=True"

--- a/pybaseball/statcast_batter.py
+++ b/pybaseball/statcast_batter.py
@@ -140,7 +140,7 @@ def statcast_batter_run_value(year: int) -> pd.DataFrame():
 
     ARGUMENTS:
         year(int): year data is retrieved for.
-        Data is can only be retrieved for a single year at a time
+        Data can only be retrieved for a single year at a time
 
     Returns:
         data(pd.DataFrame): clean dataframe from Savant Return

--- a/pybaseball/statcast_batter.py
+++ b/pybaseball/statcast_batter.py
@@ -67,14 +67,11 @@ def statcast_batter_expected_stats(
         minPA: The minimum number of plate appearances for each player. If a player falls below this threshold,
             they will be excluded from the results. If no value is specified, only qualified batters will be returned.
     """
-    try:
-        url = f"https://baseballsavant.mlb.com/leaderboard/expected_statistics?type=batter&year={year}&position=&team=&filterType=pa&min={minPA}&csv=true"
-        res = requests.get(url, timeout=None).content
-        data = pd.read_csv(io.StringIO(res.decode("utf-8")))
-        data = sanitize_statcast_columns(data)
-        return data
-    except Exception as e:
-        raise KeyError(f"URL {e} is unreachable")
+    url = f"https://baseballsavant.mlb.com/leaderboard/expected_statistics?type=batter&year={year}&position=&team=&filterType=pa&min={minPA}&csv=true"
+    res = requests.get(url, timeout=None).content
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
+    data = sanitize_statcast_columns(data)
+    return data
 
 
 @cache.df_cache()
@@ -123,14 +120,11 @@ def statcast_batter_bat_tracking(
             they will be excluded from the results. If no value is specified, the default number of competitive swings
             is qualified.
     """
-    try:
-        url = f"https://baseballsavant.mlb.com/leaderboard/bat-tracking/swing-path-attack-angle?dateStart={year}-01-01&dateEnd={year}-12-31&gameType=Regular&minSwings={minSwings}&minGroupSwings=1&seasonStart={year}&seasonEnd={year}&type=batter&csv=true"
-        res = requests.get(url, timeout=None).content
-        data = pd.read_csv(io.StringIO(res.decode("utf-8")))
-        data = sanitize_statcast_columns(data)
-        return data
-    except Exception as e:
-        raise KeyError(f"URL {e} is unreachable")
+    url = f"https://baseballsavant.mlb.com/leaderboard/bat-tracking/swing-path-attack-angle?dateStart={year}-01-01&dateEnd={year}-12-31&gameType=Regular&minSwings={minSwings}&minGroupSwings=1&seasonStart={year}&seasonEnd={year}&type=batter&csv=true"
+    res = requests.get(url, timeout=None).content
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
+    data = sanitize_statcast_columns(data)
+    return data
 
 
 @cache.df_cache()

--- a/pybaseball/statcast_batter.py
+++ b/pybaseball/statcast_batter.py
@@ -1,4 +1,5 @@
 import io
+from http.client import HTTPException
 from typing import Optional, Union
 
 import pandas as pd
@@ -134,15 +135,24 @@ def statcast_batter_bat_tracking(
 
 @cache.df_cache()
 def statcast_batter_run_value(year: int) -> pd.DataFrame():
+    """
+    Retrieve a Batter's Run Value from Baseball Savant's URL
+
+    ARGUMENTS:
+        year(int): year data is retrieved for.
+        Data is can only be retrieved for a single year at a time
+
+    Returns:
+        data(pd.DataFrame): clean dataframe from Savant Return
+
+    """
     try:
         url = f"https://baseballsavant.mlb.com/leaderboard/swing-take?year={year}&team=&leverage=Neutral&group=Batter&type=All&sub_type=null&min=q&csv=True"
         res = requests.get(url, timeout=None).content
         data = pd.read_csv(io.StringIO(res.decode("utf-8")))
         data = sanitize_statcast_columns(data)
         return data
-    except Exception as e:
-        raise KeyError(f"URL {e} is unreachable")
-
-
-"https://baseballsavant.mlb.com/leaderboard/swing-take?year={year}&team=&leverage=Neutral&group=Batter&type=All&sub_type=null&min=q&csv=True"
-"https://baseballsavant.mlb.com/leaderboard/swing-take?year={year}&team=&leverage=Neutral&group=Pitcher&type=All&sub_type=null&min=q&csv=True"
+    except HTTPException as error:
+        raise ConnectionError(f"URL {error} is unreachable")
+    finally:
+        raise KeyError(f"An Error Occurred in Acquiring the Data")

--- a/pybaseball/statcast_fielding.py
+++ b/pybaseball/statcast_fielding.py
@@ -54,7 +54,7 @@ def statcast_fielding_run_value(year: int, pos: Union[int, str], min_inn: int = 
 			the given threshold
 	"""
 	pos = norm_positions(pos)
-	url = f"https://baseballsavant.mlb.com/leaderboard/fielding-run-value?year={year}&min={min_inn}&pos={pos}&roles=&viz=show&csv=true"
+	url = f"https://baseballsavant.mlb.com/leaderboard/fielding-run-value?gameType=Regular&seasonStart={year}&seasonEnd={year}&type=fielder&position={pos}&minInnings={min_inn}&minResults=1&csv=true"
 	res = requests.get(url, timeout=None).content
 	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
 	data = sanitize_statcast_columns(data)
@@ -140,10 +140,11 @@ def statcast_catcher_framing(year: int, min_called_p: Union[int, str] = "q") -> 
 		min_called_p: The minimum number of called pitches for the catcher in the shadow zone. Statcast's default 
 		is players with at least 6 called pitches in the shadow zone per team game.
 	"""
-	url = f"https://baseballsavant.mlb.com/catcher_framing?year={year}&team=&min={min_called_p}&sort=4,1&csv=true"
+	url = f"https://baseballsavant.mlb.com/leaderboard/catcher-framing?type=catcher&seasonStart={year}&seasonEnd={year}&team=&min={min_called_p}&sortColumn=rv_tot&sortDirection=desc&csv=true"
 	res = requests.get(url, timeout=None).content
 	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
 	data = sanitize_statcast_columns(data)
+	print(data)
 	# CSV includes league average player, which we drop from the result
-	return data.loc[data.last_name.notna()].reset_index(drop=True)	
+	return data.loc[data.name.notna()].reset_index(drop=True)
 

--- a/pybaseball/statcast_fielding.py
+++ b/pybaseball/statcast_fielding.py
@@ -7,144 +7,165 @@ import requests
 from . import cache
 from .utils import norm_positions, sanitize_statcast_columns
 
-@cache.df_cache()
-def statcast_outs_above_average(year: int, pos: Union[int, str], min_att: Union[int, str] = "q", view: str = "Fielder") -> pd.DataFrame:
-	"""Scrapes outs above average from baseball savant for a given year and position
-
-	Args:
-		year (int): Season to pull
-		pos (Union[int, str]): Numerical position (e.g. 3 for 1B, 4 for 2B). Catchers not supported
-		min_att (Union[int, str], optional): Integer number of attempts required or "q" for qualified. 
-			Defaults to "q".
-		view (str, optional): Perspective of defensive metrics. String argument supports "Fielder", "Pitcher", "Fielding_Team", "Batter", and "Batting_Team"
-			Defaults to "Fielder"
-
-	Raises:
-		ValueError: Failure if catcher is passed
-
-	Returns:
-		pd.DataFrame: Dataframe of defensive OAA for the given year and position for players who have met
-			the given threshold
-	"""
-	pos = norm_positions(pos)
-	# catcher is not included in this leaderboard
-	if pos == "2":
-		raise ValueError("This particular leaderboard does not include catchers!")
-	url = f"https://baseballsavant.mlb.com/leaderboard/outs_above_average?type={view}&startYear={year}&endYear={year}&split=no&team=&range=year&min={min_att}&pos={pos}&roles=&viz=hide&csv=true"
-	res = requests.get(url, timeout=None).content
-	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
-	data = sanitize_statcast_columns(data)
-	return data
 
 @cache.df_cache()
-def statcast_fielding_run_value(year: int, pos: Union[int, str], min_inn: int = 100) -> pd.DataFrame:
-	"""Scrapes fielding run value from baseball savant for a given year and position
+def statcast_outs_above_average(
+    year: int,
+    pos: Union[int, str],
+    min_att: Union[int, str] = "q",
+    view: str = "Fielder",
+) -> pd.DataFrame:
+    """Scrapes outs above average from baseball savant for a given year and position
 
-	Args:
-		year (int): Season to pull, if 0 returns merged data for all available years.
-		pos (Union[int, str]): Numerical position (e.g. 3 for 1B, 4 for 2B). Catchers ARE supported
-		min_inn (int, optional): Integer number of attempts required.
-			Defaults to 100.
+    Args:
+            year (int): Season to pull
+            pos (Union[int, str]): Numerical position (e.g. 3 for 1B, 4 for 2B). Catchers not supported
+            min_att (Union[int, str], optional): Integer number of attempts required or "q" for qualified.
+                    Defaults to "q".
+            view (str, optional): Perspective of defensive metrics. String argument supports "Fielder", "Pitcher", "Fielding_Team", "Batter", and "Batting_Team"
+                    Defaults to "Fielder"
 
-	Raises:
-		ValueError: Failure if pitcher is passed
+    Raises:
+            ValueError: Failure if catcher is passed
 
-	Returns:
-		pd.DataFrame: Dataframe of defensive FRV for the given year and position for players who have met
-			the given threshold
-	"""
-	pos = norm_positions(pos)
-	url = f"https://baseballsavant.mlb.com/leaderboard/fielding-run-value?gameType=Regular&seasonStart={year}&seasonEnd={year}&type=fielder&position={pos}&minInnings={min_inn}&minResults=1&csv=true"
-	res = requests.get(url, timeout=None).content
-	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
-	data = sanitize_statcast_columns(data)
-	return data
+    Returns:
+            pd.DataFrame: Dataframe of defensive OAA for the given year and position for players who have met
+                    the given threshold
+    """
+    pos = norm_positions(pos)
+    # catcher is not included in this leaderboard
+    if pos == "2":
+        raise ValueError("This particular leaderboard does not include catchers!")
+    url = f"https://baseballsavant.mlb.com/leaderboard/outs_above_average?type={view}&startYear={year}&endYear={year}&split=no&team=&range=year&min={min_att}&pos={pos}&roles=&viz=hide&csv=true"
+    res = requests.get(url, timeout=None).content
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
+    data = sanitize_statcast_columns(data)
+    return data
 
-@cache.df_cache()
-def statcast_outfield_directional_oaa(year: int, min_opp: Union[int, str] = "q") -> pd.DataFrame:
-	"""
-	Retrieves outfielders' directional OAA data for the given year and number of opportunities. The directions are 
-	Back Left, Back, Back Right, In Left, In, and In Right.
-
-	ARGUMENTS
-		year: The year for which you wish to retrieve batted ball against data. Format: YYYY. 
-		min_opp: The minimum number of opportunities for the player to be included in the result. Statcast's 
-		default is players with at least 1 fielding attempt per game.
-	"""
-	url = f"https://baseballsavant.mlb.com/directional_outs_above_average?year={year}&min={min_opp}&team=&csv=true"
-	res = requests.get(url, timeout=None).content
-	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
-	data = sanitize_statcast_columns(data)
-	return data
 
 @cache.df_cache()
-def statcast_outfield_catch_prob(year: int, min_opp: Union[int, str] = "q") -> pd.DataFrame:
-	"""
-	Retrieves aggregated data for outfielder performance on fielding attempt types, binned into five star categories, 
-	for the given year and number of opportunities.
+def statcast_fielding_run_value(
+    year: int, pos: Union[int, str], min_inn: int = 100
+) -> pd.DataFrame:
+    """Scrapes fielding run value from baseball savant for a given year and position
 
-	ARGUMENTS
-		year: The year for which you wish to retrieve batted ball against data. Format: YYYY. 
-		min_opp: The minimum number of opportunities for the player to be included in the result. Statcast's 
-		default is players with at least 1 fielding attempt per game.
-	"""
-	url = f"https://baseballsavant.mlb.com/leaderboard/catch_probability?type=player&min={min_opp}&year={year}&total=&csv=true"
-	res = requests.get(url, timeout=None).content
-	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
-	data = sanitize_statcast_columns(data)
-	return data
+    Args:
+            year (int): Season to pull, if 0 returns merged data for all available years.
+            pos (Union[int, str]): Numerical position (e.g. 3 for 1B, 4 for 2B). Catchers ARE supported
+            min_inn (int, optional): Integer number of attempts required.
+                    Defaults to 100.
+
+    Raises:
+            ValueError: Failure if pitcher is passed
+
+    Returns:
+            pd.DataFrame: Dataframe of defensive FRV for the given year and position for players who have met
+                    the given threshold
+    """
+    pos = norm_positions(pos)
+    url = f"https://baseballsavant.mlb.com/leaderboard/fielding-run-value?gameType=Regular&seasonStart={year}&seasonEnd={year}&type=fielder&position={pos}&minInnings={min_inn}&minResults=1&csv=true"
+    res = requests.get(url, timeout=None).content
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
+    data = sanitize_statcast_columns(data)
+    return data
+
+
+@cache.df_cache()
+def statcast_outfield_directional_oaa(
+    year: int, min_opp: Union[int, str] = "q"
+) -> pd.DataFrame:
+    """
+    Retrieves outfielders' directional OAA data for the given year and number of opportunities. The directions are
+    Back Left, Back, Back Right, In Left, In, and In Right.
+
+    ARGUMENTS
+            year: The year for which you wish to retrieve batted ball against data. Format: YYYY.
+            min_opp: The minimum number of opportunities for the player to be included in the result. Statcast's
+            default is players with at least 1 fielding attempt per game.
+    """
+    url = f"https://baseballsavant.mlb.com/directional_outs_above_average?year={year}&min={min_opp}&team=&csv=true"
+    res = requests.get(url, timeout=None).content
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
+    data = sanitize_statcast_columns(data)
+    return data
+
+
+@cache.df_cache()
+def statcast_outfield_catch_prob(
+    year: int, min_opp: Union[int, str] = "q"
+) -> pd.DataFrame:
+    """
+    Retrieves aggregated data for outfielder performance on fielding attempt types, binned into five star categories,
+    for the given year and number of opportunities.
+
+    ARGUMENTS
+            year: The year for which you wish to retrieve batted ball against data. Format: YYYY.
+            min_opp: The minimum number of opportunities for the player to be included in the result. Statcast's
+            default is players with at least 1 fielding attempt per game.
+    """
+    url = f"https://baseballsavant.mlb.com/leaderboard/catch_probability?type=player&min={min_opp}&year={year}&total=&csv=true"
+    res = requests.get(url, timeout=None).content
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
+    data = sanitize_statcast_columns(data)
+    return data
+
 
 @cache.df_cache()
 def statcast_outfielder_jump(year: int, min_att: Union[int, str] = "q") -> pd.DataFrame:
-	"""
-	Retrieves data on outfielder's jump to the ball for the given year and number of attempts. Jump is calculated 
-	only for two star or harder plays (90% or less catch probabiility).
+    """
+    Retrieves data on outfielder's jump to the ball for the given year and number of attempts. Jump is calculated
+    only for two star or harder plays (90% or less catch probabiility).
 
-	ARGUMENTS
-		year: The year for which you wish to retrieve batted ball against data. Format: YYYY. 
-		min_att: The minimum number of attempts for the player to be included in the result. Statcast's default 
-			is players with at least 2 two star or harder fielding attempts per team game / 5.
-	"""
-	url = f"https://baseballsavant.mlb.com/leaderboard/outfield_jump?year={year}&min={min_att}&csv=true"
-	res = requests.get(url, timeout=None).content
-	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
-	data = sanitize_statcast_columns(data)
-	return data
+    ARGUMENTS
+            year: The year for which you wish to retrieve batted ball against data. Format: YYYY.
+            min_att: The minimum number of attempts for the player to be included in the result. Statcast's default
+                    is players with at least 2 two star or harder fielding attempts per team game / 5.
+    """
+    url = f"https://baseballsavant.mlb.com/leaderboard/outfield_jump?year={year}&min={min_att}&csv=true"
+    res = requests.get(url, timeout=None).content
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
+    data = sanitize_statcast_columns(data)
+    return data
 
-@cache.df_cache()
-def statcast_catcher_poptime(year: int, min_2b_att: int = 5, min_3b_att: int = 0) -> pd.DataFrame:
-	"""
-	Retrieves pop time data for catchers given year and minimum stolen base attempts for second and third base. 
-	Pop time is measured as the time from the moment the ball hits the catcher's mitt to when it reaches the projected 
-	receiving point at the center of the fielder's base.
-
-	ARGUMENTS
-		year: The year for which you wish to retrieve batted ball against data. Format: YYYY. 
-		min_2b_att: The minimum number of stolen base attempts for second base against the catcher. Statcast's default is 5. 
-		min_3b_att: The minimum number of stolen base attempts for third base against the catcher. Statcast's default is 0.
-	"""
-	# currently no 2020 data
-	url = f"https://baseballsavant.mlb.com/leaderboard/poptime?year={year}&team=&min2b={min_2b_att}&min3b={min_3b_att}&csv=true"
-	res = requests.get(url, timeout=None).content
-	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
-	return data
 
 @cache.df_cache()
-def statcast_catcher_framing(year: int, min_called_p: Union[int, str] = "q") -> pd.DataFrame:
-	"""
-	Retrieves the catcher's framing results for the given year and minimum called pitches. It uses eight zones around 
-	the strike zone (aka "shadow zone") and gives the percentage of time the catcher gets the strike called in each zone.
+def statcast_catcher_poptime(
+    year: int, min_2b_att: int = 5, min_3b_att: int = 0
+) -> pd.DataFrame:
+    """
+    Retrieves pop time data for catchers given year and minimum stolen base attempts for second and third base.
+    Pop time is measured as the time from the moment the ball hits the catcher's mitt to when it reaches the projected
+    receiving point at the center of the fielder's base.
 
-	ARGUMENTS
-		year: The year for which you wish to retrieve batted ball against data. Format: YYYY. 
-		min_called_p: The minimum number of called pitches for the catcher in the shadow zone. Statcast's default 
-		is players with at least 6 called pitches in the shadow zone per team game.
-	"""
-	url = f"https://baseballsavant.mlb.com/leaderboard/catcher-framing?type=catcher&seasonStart={year}&seasonEnd={year}&team=&min={min_called_p}&sortColumn=rv_tot&sortDirection=desc&csv=true"
-	res = requests.get(url, timeout=None).content
-	data = pd.read_csv(io.StringIO(res.decode('utf-8')))
-	data = sanitize_statcast_columns(data)
-	print(data)
-	# CSV includes league average player, which we drop from the result
-	return data.loc[data.name.notna()].reset_index(drop=True)
+    ARGUMENTS
+            year: The year for which you wish to retrieve batted ball against data. Format: YYYY.
+            min_2b_att: The minimum number of stolen base attempts for second base against the catcher. Statcast's default is 5.
+            min_3b_att: The minimum number of stolen base attempts for third base against the catcher. Statcast's default is 0.
+    """
+    # currently no 2020 data
+    url = f"https://baseballsavant.mlb.com/leaderboard/poptime?year={year}&team=&min2b={min_2b_att}&min3b={min_3b_att}&csv=true"
+    res = requests.get(url, timeout=None).content
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
+    return data
 
+
+@cache.df_cache()
+def statcast_catcher_framing(
+    year: int, min_called_p: Union[int, str] = "q"
+) -> pd.DataFrame:
+    """
+    Retrieves the catcher's framing results for the given year and minimum called pitches. It uses eight zones around
+    the strike zone (aka "shadow zone") and gives the percentage of time the catcher gets the strike called in each zone.
+
+    ARGUMENTS
+            year: The year for which you wish to retrieve batted ball against data. Format: YYYY.
+            min_called_p: The minimum number of called pitches for the catcher in the shadow zone. Statcast's default
+            is players with at least 6 called pitches in the shadow zone per team game.
+    """
+    url = f"https://baseballsavant.mlb.com/leaderboard/catcher-framing?type=catcher&seasonStart={year}&seasonEnd={year}&team=&min={min_called_p}&sortColumn=rv_tot&sortDirection=desc&csv=true"
+    res = requests.get(url, timeout=None).content
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
+    data = sanitize_statcast_columns(data)
+    print(data)
+    # CSV includes league average player, which we drop from the result
+    return data.loc[data.name.notna()].reset_index(drop=True)

--- a/pybaseball/statcast_pitcher.py
+++ b/pybaseball/statcast_pitcher.py
@@ -6,18 +6,26 @@ import pandas as pd
 import requests
 
 from . import cache
-from .utils import norm_pitch_code, sanitize_input, split_request, sanitize_statcast_columns
+from .utils import (
+    norm_pitch_code,
+    sanitize_input,
+    split_request,
+    sanitize_statcast_columns,
+)
 
 
-def statcast_pitcher(start_dt: Optional[str] = None, end_dt: Optional[str] = None,
-                     player_id: Optional[int] = None) -> pd.DataFrame:
+def statcast_pitcher(
+    start_dt: Optional[str] = None,
+    end_dt: Optional[str] = None,
+    player_id: Optional[int] = None,
+) -> pd.DataFrame:
     """
     Pulls statcast pitch-level data from Baseball Savant for a given pitcher.
 
     ARGUMENTS
         start_dt : YYYY-MM-DD : the first date for which you want a player's statcast data
         end_dt : YYYY-MM-DD : the final date for which you want data
-        player_id : INT : the player's MLBAM ID. Find this by calling pybaseball.playerid_lookup(last_name, first_name), 
+        player_id : INT : the player's MLBAM ID. Find this by calling pybaseball.playerid_lookup(last_name, first_name),
         finding the correct player, and selecting their key_mlbam.
     """
     sanitize_input(start_dt, end_dt, player_id)
@@ -27,45 +35,49 @@ def statcast_pitcher(start_dt: Optional[str] = None, end_dt: Optional[str] = Non
     assert end_dt
     assert player_id
 
-    url = 'https://baseballsavant.mlb.com/statcast_search/csv?all=true&hfPT=&hfAB=&hfBBT=&hfPR=&hfZ=&stadium=&hfBBL=&hfNewZones=&hfGT=R%7CPO%7CS%7C=&hfSea=&hfSit=&player_type=pitcher&hfOuts=&opponent=&pitcher_throws=&batter_stands=&hfSA=&game_date_gt={}&game_date_lt={}&pitchers_lookup%5B%5D={}&team=&position=&hfRO=&home_road=&hfFlag=&metric_1=&hfInn=&min_pitches=0&min_results=0&group_by=name&sort_col=pitches&player_event_sort=h_launch_speed&sort_order=desc&min_abs=0&type=details&'
+    url = "https://baseballsavant.mlb.com/statcast_search/csv?all=true&hfPT=&hfAB=&hfBBT=&hfPR=&hfZ=&stadium=&hfBBL=&hfNewZones=&hfGT=R%7CPO%7CS%7C=&hfSea=&hfSit=&player_type=pitcher&hfOuts=&opponent=&pitcher_throws=&batter_stands=&hfSA=&game_date_gt={}&game_date_lt={}&pitchers_lookup%5B%5D={}&team=&position=&hfRO=&home_road=&hfFlag=&metric_1=&hfInn=&min_pitches=0&min_results=0&group_by=name&sort_col=pitches&player_event_sort=h_launch_speed&sort_order=desc&min_abs=0&type=details&"
     df = split_request(start_dt, end_dt, player_id, url)
 
     return df
 
 
 @cache.df_cache()
-def statcast_pitcher_exitvelo_barrels(year: int, minBBE: Union[int, str] = "q") -> pd.DataFrame:
+def statcast_pitcher_exitvelo_barrels(
+    year: int, minBBE: Union[int, str] = "q"
+) -> pd.DataFrame:
     """
     Retrieves batted ball against data for all qualified pitchers in a given year.
 
     ARGUMENTS
         year: The year for which you wish to retrieve batted ball against data. Format: YYYY.
-        minBBE: The minimum number of batted ball against events for each pitcher. If a player falls below this 
-            threshold, they will be excluded from the results. If no value is specified, only qualified pitchers 
+        minBBE: The minimum number of batted ball against events for each pitcher. If a player falls below this
+            threshold, they will be excluded from the results. If no value is specified, only qualified pitchers
             will be returned.
     """
     url = f"https://baseballsavant.mlb.com/leaderboard/statcast?type=pitcher&year={year}&position=&team=&min={minBBE}&csv=true"
     res = requests.get(url, timeout=None).content
-    data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
     data = sanitize_statcast_columns(data)
     return data
 
 
 @cache.df_cache()
-def statcast_pitcher_expected_stats(year: int, minPA: Union[int, str] = "q") -> pd.DataFrame:
+def statcast_pitcher_expected_stats(
+    year: int, minPA: Union[int, str] = "q"
+) -> pd.DataFrame:
     """
     Retrieves expected stats based on quality of batted ball contact against in a given year.
 
     ARGUMENTS
         year: The year for which you wish to retrieve expected stats data. Format: YYYY.
-        minPA: The minimum number of plate appearances against for each player. If a player falls below this threshold, 
+        minPA: The minimum number of plate appearances against for each player. If a player falls below this threshold,
             they will be excluded from the results. If no value is specified, only qualified pitchers will be returned.
     """
 
     try:
         url = f"https://baseballsavant.mlb.com/leaderboard/expected_statistics?type=pitcher&year={year}&position=&team=&filterType=pa&min={minPA}&csv=true"
         res = requests.get(url, timeout=None).content
-        data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+        data = pd.read_csv(io.StringIO(res.decode("utf-8")))
         data = sanitize_statcast_columns(data)
         return data
     except Exception as e:
@@ -73,7 +85,9 @@ def statcast_pitcher_expected_stats(year: int, minPA: Union[int, str] = "q") -> 
 
 
 @cache.df_cache()
-def statcast_pitcher_pitch_arsenal(year: int, minP: int = 250, arsenal_type: str = "avg_speed") -> pd.DataFrame:
+def statcast_pitcher_pitch_arsenal(
+    year: int, minP: int = 250, arsenal_type: str = "avg_speed"
+) -> pd.DataFrame:
     """
     Retrieves high level stats on each pitcher's arsenal in a given year.
 
@@ -87,10 +101,12 @@ def statcast_pitcher_pitch_arsenal(year: int, minP: int = 250, arsenal_type: str
     """
     arsenals = ["avg_speed", "n_", "avg_spin"]
     if arsenal_type not in arsenals:
-        raise ValueError(f"Not a valid arsenal_type. Must be one of {', '.join(arsenals)}.")
+        raise ValueError(
+            f"Not a valid arsenal_type. Must be one of {', '.join(arsenals)}."
+        )
     url = f"https://baseballsavant.mlb.com/leaderboard/pitch-arsenals?year={year}&min={minP}&type={arsenal_type}&hand=&csv=true"
     res = requests.get(url, timeout=None).content
-    data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
     data = sanitize_statcast_columns(data)
     return data
 
@@ -109,13 +125,15 @@ def statcast_pitcher_arsenal_stats(year: int, minPA: int = 25) -> pd.DataFrame:
     # test to see if pitch types needs to be implemented or if user can subset on their own
     url = f"https://baseballsavant.mlb.com/leaderboard/pitch-arsenal-stats?type=pitcher&pitchType=&year={year}&team=&min={minPA}&csv=true"
     res = requests.get(url, timeout=None).content
-    data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
     data = sanitize_statcast_columns(data)
     return data
 
 
 @cache.df_cache()
-def statcast_pitcher_pitch_movement(year: int, minP: Union[int, str] = "q", pitch_type: str = "FF") -> pd.DataFrame:
+def statcast_pitcher_pitch_movement(
+    year: int, minP: Union[int, str] = "q", pitch_type: str = "FF"
+) -> pd.DataFrame:
     """
     Retrieves pitch movement stats for all qualified pitchers with a specified pitch type for a given year.
 
@@ -129,13 +147,15 @@ def statcast_pitcher_pitch_movement(year: int, minP: Union[int, str] = "q", pitc
     pitch_type = norm_pitch_code(pitch_type)
     url = f"https://baseballsavant.mlb.com/leaderboard/pitch-movement?year={year}&team=&min={minP}&pitch_type={pitch_type}&hand=&x=pitcher_break_x_hidden&z=pitcher_break_z_hidden&csv=true"
     res = requests.get(url, timeout=None).content
-    data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
     data = sanitize_statcast_columns(data)
     return data
 
 
 @cache.df_cache()
-def statcast_pitcher_active_spin(year: int, minP: int = 250, _type: str = 'spin-based') -> pd.DataFrame:
+def statcast_pitcher_active_spin(
+    year: int, minP: int = 250, _type: str = "spin-based"
+) -> pd.DataFrame:
     """
     Retrieves active spin stats on all of a pitchers' pitches in a given year.
 
@@ -157,19 +177,22 @@ def statcast_pitcher_active_spin(year: int, minP: int = 250, _type: str = 'spin-
     """
     url = f"https://baseballsavant.mlb.com/leaderboard/active-spin?year={year}_{_type}&min={minP}&hand=&csv=true"
     res = requests.get(url, timeout=None).content
-    if res and '<html' in res.decode('utf-8'):
+    if res and "<html" in res.decode("utf-8"):
         # This did no go as planned. Statcast redirected us back to HTML :(
-        if _type == 'spin-based':
+        if _type == "spin-based":
             warnings.warn(
-                f'Could not get active spin results for year {year} that are "spin-based". Trying to get the older "observed" results.')
-            return statcast_pitcher_active_spin(year, minP, 'observed')
+                f'Could not get active spin results for year {year} that are "spin-based". Trying to get the older "observed" results.'
+            )
+            return statcast_pitcher_active_spin(year, minP, "observed")
 
-        warnings.warn("Statcast did not return any active spin results for the query provided.")
+        warnings.warn(
+            "Statcast did not return any active spin results for the query provided."
+        )
         return pd.DataFrame()
 
-    data = pd.read_csv(io.StringIO(res.decode('utf-8')))
-    if _type == 'spin-based' and (data is None or data.empty):
-        return statcast_pitcher_active_spin(year, minP, 'observed')
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
+    if _type == "spin-based" and (data is None or data.empty):
+        return statcast_pitcher_active_spin(year, minP, "observed")
 
     data = sanitize_statcast_columns(data)
     return data
@@ -186,14 +209,19 @@ def statcast_pitcher_percentile_ranks(year: int) -> pd.DataFrame:
     """
     url = f"https://baseballsavant.mlb.com/leaderboard/percentile-rankings?type=pitcher&year={year}&position=&team=&csv=true"
     res = requests.get(url, timeout=None).content
-    data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
     # URL returns a null player with player id 999999, which we want to drop
     return data.loc[data.player_name.notna()].reset_index(drop=True)
 
 
 @cache.df_cache()
-def statcast_pitcher_spin_dir_comp(year: int, pitch_a: str = "FF", pitch_b: str = "CH", minP: int = 100,
-                                   pitcher_pov: bool = True) -> pd.DataFrame:
+def statcast_pitcher_spin_dir_comp(
+    year: int,
+    pitch_a: str = "FF",
+    pitch_b: str = "CH",
+    minP: int = 100,
+    pitcher_pov: bool = True,
+) -> pd.DataFrame:
     """
     Retrieves spin comparisons between two pitches for qualifying pitchers in a given year.
 
@@ -213,13 +241,15 @@ def statcast_pitcher_spin_dir_comp(year: int, pitch_a: str = "FF", pitch_b: str 
     pov = "Pit" if pitcher_pov else "Bat"
     url = f"https://baseballsavant.mlb.com/leaderboard/spin-direction-comparison?year={year}&type={pitch_a} / {pitch_b}&min={minP}&team=&pov={pov}&sort=11&sortDir=asc&csv=true"
     res = requests.get(url, timeout=None).content
-    data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
     data = sanitize_statcast_columns(data)
     return data
 
 
 @cache.df_cache()
-def statcast_pitcher_bat_tracking(year: int, minSwings: Union[int, str] = "q") -> pd.DataFrame:
+def statcast_pitcher_bat_tracking(
+    year: int, minSwings: Union[int, str] = "q"
+) -> pd.DataFrame:
     """
     Retrieves the bat tracking data against for pitchers.
 
@@ -230,16 +260,17 @@ def statcast_pitcher_bat_tracking(year: int, minSwings: Union[int, str] = "q") -
     """
     url = f"https://baseballsavant.mlb.com/leaderboard/bat-tracking/swing-path-attack-angle?dateStart={year}-01-01&dateEnd={year}-12-31&gameType=Regular&minSwings={minSwings}&minGroupSwings=1&seasonStart={year}&seasonEnd={year}&type=pitcher&csv=true"
     res = requests.get(url, timeout=None).content
-    data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    data = pd.read_csv(io.StringIO(res.decode("utf-8")))
     data = sanitize_statcast_columns(data)
     return data
 
+
 @cache.df_cache()
-def statcast_pitcher_run_value(year:int) ->pd.DataFrame():
+def statcast_pitcher_run_value(year: int) -> pd.DataFrame():
     try:
         url = f"https://baseballsavant.mlb.com/leaderboard/swing-take?year={year}&team=&leverage=Neutral&group=Pitcher&type=All&sub_type=null&min=q&csv=True"
         res = requests.get(url, timeout=None).content
-        data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+        data = pd.read_csv(io.StringIO(res.decode("utf-8")))
         data = sanitize_statcast_columns(data)
         return data
     except Exception as e:

--- a/pybaseball/statcast_pitcher.py
+++ b/pybaseball/statcast_pitcher.py
@@ -273,7 +273,7 @@ def statcast_pitcher_run_value(year: int) -> pd.DataFrame():
 
     ARGUMENTS:
         year(int): year data is retrieved for.
-        Data is can only be retrieved for a single year at a time
+        Data can only be retrieved for a single year at a time
 
     Returns:
         data(pd.DataFrame): clean dataframe from Savant Return

--- a/pybaseball/statcast_pitcher.py
+++ b/pybaseball/statcast_pitcher.py
@@ -233,3 +233,14 @@ def statcast_pitcher_bat_tracking(year: int, minSwings: Union[int, str] = "q") -
     data = pd.read_csv(io.StringIO(res.decode('utf-8')))
     data = sanitize_statcast_columns(data)
     return data
+
+@cache.df_cache()
+def statcast_pitcher_run_value(year:int) ->pd.DataFrame():
+    try:
+        url = f"https://baseballsavant.mlb.com/leaderboard/swing-take?year={year}&team=&leverage=Neutral&group=Pitcher&type=All&sub_type=null&min=q&csv=True"
+        res = requests.get(url, timeout=None).content
+        data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+        data = sanitize_statcast_columns(data)
+        return data
+    except Exception as e:
+        raise KeyError(f"URL {e} is unreachable")

--- a/pybaseball/statcast_pitcher.py
+++ b/pybaseball/statcast_pitcher.py
@@ -9,7 +9,8 @@ from . import cache
 from .utils import norm_pitch_code, sanitize_input, split_request, sanitize_statcast_columns
 
 
-def statcast_pitcher(start_dt: Optional[str] = None, end_dt: Optional[str] = None, player_id: Optional[int] = None) -> pd.DataFrame:
+def statcast_pitcher(start_dt: Optional[str] = None, end_dt: Optional[str] = None,
+                     player_id: Optional[int] = None) -> pd.DataFrame:
     """
     Pulls statcast pitch-level data from Baseball Savant for a given pitcher.
 
@@ -31,6 +32,7 @@ def statcast_pitcher(start_dt: Optional[str] = None, end_dt: Optional[str] = Non
 
     return df
 
+
 @cache.df_cache()
 def statcast_pitcher_exitvelo_barrels(year: int, minBBE: Union[int, str] = "q") -> pd.DataFrame:
     """
@@ -48,6 +50,7 @@ def statcast_pitcher_exitvelo_barrels(year: int, minBBE: Union[int, str] = "q") 
     data = sanitize_statcast_columns(data)
     return data
 
+
 @cache.df_cache()
 def statcast_pitcher_expected_stats(year: int, minPA: Union[int, str] = "q") -> pd.DataFrame:
     """
@@ -58,11 +61,16 @@ def statcast_pitcher_expected_stats(year: int, minPA: Union[int, str] = "q") -> 
         minPA: The minimum number of plate appearances against for each player. If a player falls below this threshold, 
             they will be excluded from the results. If no value is specified, only qualified pitchers will be returned.
     """
-    url = f"https://baseballsavant.mlb.com/leaderboard/expected_statistics?type=pitcher&year={year}&position=&team=&min={minPA}&csv=true"
-    res = requests.get(url, timeout=None).content
-    data = pd.read_csv(io.StringIO(res.decode('utf-8')))
-    data = sanitize_statcast_columns(data)
-    return data
+
+    try:
+        url = f"https://baseballsavant.mlb.com/leaderboard/expected_statistics?type=pitcher&year={year}&position=&team=&filterType=pa&min={minPA}&csv=true"
+        res = requests.get(url, timeout=None).content
+        data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+        data = sanitize_statcast_columns(data)
+        return data
+    except Exception as e:
+        raise KeyError(f"URL {e} is unreachable")
+
 
 @cache.df_cache()
 def statcast_pitcher_pitch_arsenal(year: int, minP: int = 250, arsenal_type: str = "avg_speed") -> pd.DataFrame:
@@ -71,10 +79,10 @@ def statcast_pitcher_pitch_arsenal(year: int, minP: int = 250, arsenal_type: str
 
     ARGUMENTS
         year: The year for which you wish to retrieve expected stats data. Format: YYYY.
-        minP: The minimum number of pitches thrown. If a player falls below this threshold, they will be excluded 
+        minP: The minimum number of pitches thrown. If a player falls below this threshold, they will be excluded
             from the results. If no value is specified, only qualified pitchers will be returned.
-        arsenal_type: The type of stat to retrieve for the pitchers' arsenals. Options include ["average_speed", 
-            "n_", "average_spin"], where "n_" corresponds to the percentage share for each pitch. If no value is 
+        arsenal_type: The type of stat to retrieve for the pitchers' arsenals. Options include ["average_speed",
+            "n_", "average_spin"], where "n_" corresponds to the percentage share for each pitch. If no value is
             specified, it will default to average speed.
     """
     arsenals = ["avg_speed", "n_", "avg_spin"]
@@ -86,15 +94,16 @@ def statcast_pitcher_pitch_arsenal(year: int, minP: int = 250, arsenal_type: str
     data = sanitize_statcast_columns(data)
     return data
 
+
 @cache.df_cache()
 def statcast_pitcher_arsenal_stats(year: int, minPA: int = 25) -> pd.DataFrame:
     """
-    Retrieves assorted basic and advanced outcome stats for pitchers' arsenals in a given year. Run value and 
+    Retrieves assorted basic and advanced outcome stats for pitchers' arsenals in a given year. Run value and
         whiff % are defined on a per pitch basis, while all others are on a per PA basis.
-    
+
     ARGUMENTS
         year: The year for which you wish to retrieve expected stats data. Format: YYYY.
-        minPA: The minimum number of plate appearances against. If a player falls below this threshold, they will be 
+        minPA: The minimum number of plate appearances against. If a player falls below this threshold, they will be
             excluded from the results. If no value is specified, it will default to 25 plate appearances against.
     """
     # test to see if pitch types needs to be implemented or if user can subset on their own
@@ -104,6 +113,7 @@ def statcast_pitcher_arsenal_stats(year: int, minPA: int = 25) -> pd.DataFrame:
     data = sanitize_statcast_columns(data)
     return data
 
+
 @cache.df_cache()
 def statcast_pitcher_pitch_movement(year: int, minP: Union[int, str] = "q", pitch_type: str = "FF") -> pd.DataFrame:
     """
@@ -111,9 +121,9 @@ def statcast_pitcher_pitch_movement(year: int, minP: Union[int, str] = "q", pitc
 
     ARGUMENTS
         year: The year for which you wish to retrieve expected stats data. Format: YYYY.
-        minP: The minimum number of pitches thrown. If a player falls below this threshold, they will be excluded 
+        minP: The minimum number of pitches thrown. If a player falls below this threshold, they will be excluded
             from the results. If no value is specified, only qualified pitchers will be returned.
-        pitch_type: The type of pitch to retrieve movement data on. Options include ["FF", "SIFT", "CH", "CUKC", "FC", 
+        pitch_type: The type of pitch to retrieve movement data on. Options include ["FF", "SIFT", "CH", "CUKC", "FC",
             "SL", "FS", "ALL"]. Pitch names also allowed. If no value is specified, it will default to "FF".
     """
     pitch_type = norm_pitch_code(pitch_type)
@@ -123,6 +133,7 @@ def statcast_pitcher_pitch_movement(year: int, minP: Union[int, str] = "q", pitc
     data = sanitize_statcast_columns(data)
     return data
 
+
 @cache.df_cache()
 def statcast_pitcher_active_spin(year: int, minP: int = 250, _type: str = 'spin-based') -> pd.DataFrame:
     """
@@ -130,13 +141,13 @@ def statcast_pitcher_active_spin(year: int, minP: int = 250, _type: str = 'spin-
 
     ARGUMENTS
         year: The year for which you wish to retrieve expected stats data. Format: YYYY.
-        minP: The minimum number of pitches thrown. If a player falls below this threshold, they will be excluded from 
+        minP: The minimum number of pitches thrown. If a player falls below this threshold, they will be excluded from
             the results. If no value is specified, only pitchers who threw 250 or more pitches will be returned.
 
     NOTES
     Statcast supports spin-based for some years, but not others. We'll try to get that first, but if it's empty
-    we'll fall back to the observed. 
-    
+    we'll fall back to the observed.
+
     From Statcast:
       Measured active spin uses the 3D spin vector at release; this is only possible with the 2020 season going
       forward. (Label is "2020 - Spin-based" and can be read as "Active Spin using the Spin-based method".)
@@ -149,9 +160,10 @@ def statcast_pitcher_active_spin(year: int, minP: int = 250, _type: str = 'spin-
     if res and '<html' in res.decode('utf-8'):
         # This did no go as planned. Statcast redirected us back to HTML :(
         if _type == 'spin-based':
-            warnings.warn(f'Could not get active spin results for year {year} that are "spin-based". Trying to get the older "observed" results.')
+            warnings.warn(
+                f'Could not get active spin results for year {year} that are "spin-based". Trying to get the older "observed" results.')
             return statcast_pitcher_active_spin(year, minP, 'observed')
-        
+
         warnings.warn("Statcast did not return any active spin results for the query provided.")
         return pd.DataFrame()
 
@@ -162,12 +174,13 @@ def statcast_pitcher_active_spin(year: int, minP: int = 250, _type: str = 'spin-
     data = sanitize_statcast_columns(data)
     return data
 
+
 @cache.df_cache()
 def statcast_pitcher_percentile_ranks(year: int) -> pd.DataFrame:
     """
-    Retrieves percentile ranks for each player in a given year, including batters with 2.1 PA per team game and 1.25 
+    Retrieves percentile ranks for each player in a given year, including batters with 2.1 PA per team game and 1.25
     for pitchers. It includes percentiles on expected stats, batted ball data, and spin rates, among others.
-    
+
     ARGUMENTS
         year: The year for which you wish to retrieve percentile data. Format: YYYY.
     """
@@ -177,20 +190,22 @@ def statcast_pitcher_percentile_ranks(year: int) -> pd.DataFrame:
     # URL returns a null player with player id 999999, which we want to drop
     return data.loc[data.player_name.notna()].reset_index(drop=True)
 
+
 @cache.df_cache()
-def statcast_pitcher_spin_dir_comp(year: int, pitch_a: str = "FF", pitch_b: str = "CH", minP: int = 100, pitcher_pov: bool = True) -> pd.DataFrame:
+def statcast_pitcher_spin_dir_comp(year: int, pitch_a: str = "FF", pitch_b: str = "CH", minP: int = 100,
+                                   pitcher_pov: bool = True) -> pd.DataFrame:
     """
     Retrieves spin comparisons between two pitches for qualifying pitchers in a given year.
 
     ARGUMENTS
         year: The year for which you wish to retrieve percentile data. Format: YYYY.
-        pitch_a: The first pitch in the comparison. Valid pitches include "4-Seamer", "Sinker", "Changeup", "Curveball", 
+        pitch_a: The first pitch in the comparison. Valid pitches include "4-Seamer", "Sinker", "Changeup", "Curveball",
             "Cutter", "Slider", and "Sinker". Defaults to "4-Seamer". Pitch codes also accepted.
-        pitch_b: The second pitch in the comparison and must be different from pitch_a. Valid pitches include "4-Seamer", 
+        pitch_b: The second pitch in the comparison and must be different from pitch_a. Valid pitches include "4-Seamer",
             "Sinker", "Changeup", "Curveball", "Cutter", "Slider", "Sinker". Defaults to "Changeup". Pitch codes also accepted.
-        minP: The minimum number of pitches of type pitch_a thrown. If a player falls below this threshold, they will be 
+        minP: The minimum number of pitches of type pitch_a thrown. If a player falls below this threshold, they will be
             excluded from the results. If no value is specified, only pitchers who threw 100 or more pitches will be returned.
-        pitcher_pov: Boolean. If True, then direction of movement is from the pitcher's point of view. If False, then 
+        pitcher_pov: Boolean. If True, then direction of movement is from the pitcher's point of view. If False, then
             it is from the batter's point of view.
     """
     pitch_a = norm_pitch_code(pitch_a, to_word=True)
@@ -200,9 +215,11 @@ def statcast_pitcher_spin_dir_comp(year: int, pitch_a: str = "FF", pitch_b: str 
     res = requests.get(url, timeout=None).content
     data = pd.read_csv(io.StringIO(res.decode('utf-8')))
     data = sanitize_statcast_columns(data)
-    return data    
+    return data
+
+
 @cache.df_cache()
-def statcast_pitcher_bat_tracking(year: int, minSwings: Union[int,str] = "q") -> pd.DataFrame:
+def statcast_pitcher_bat_tracking(year: int, minSwings: Union[int, str] = "q") -> pd.DataFrame:
     """
     Retrieves the bat tracking data against for pitchers.
 
@@ -211,7 +228,7 @@ def statcast_pitcher_bat_tracking(year: int, minSwings: Union[int,str] = "q") ->
         minSwings: The minimum number of swings batters have taken against a pitcher. If a pitcher falls
         below the threshold, they will be excluded from the results. The default value is qualified.
     """
-    url = f"https://baseballsavant.mlb.com/leaderboard/bat-tracking?attackZone=&batSide=&contactType=&count=&dateStart={year}-01-01&dateEnd={year}-12-31&gameType=&isHardHit=&minSwings={minSwings}&minGroupSwings=1&pitchHand=&pitchType=&seasonStart=&seasonEnd=&team=&type=pitcher&csv=true"
+    url = f"https://baseballsavant.mlb.com/leaderboard/bat-tracking/swing-path-attack-angle?dateStart={year}-01-01&dateEnd={year}-12-31&gameType=Regular&minSwings={minSwings}&minGroupSwings=1&seasonStart={year}&seasonEnd={year}&type=pitcher&csv=true"
     res = requests.get(url, timeout=None).content
     data = pd.read_csv(io.StringIO(res.decode('utf-8')))
     data = sanitize_statcast_columns(data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 
 from pybaseball import cache
 
-CURRENT_SC_COLUMNS = 92
+CURRENT_SC_COLUMNS = 118
 
 _DataFrameComparer = Callable[[pd.DataFrame, pd.DataFrame], bool]
 

--- a/tests/integration/pybaseball/test_statcast_batter.py
+++ b/tests/integration/pybaseball/test_statcast_batter.py
@@ -9,7 +9,7 @@ from pybaseball.statcast_batter import (
     statcast_batter_percentile_ranks,
     statcast_batter_pitch_arsenal,
     statcast_batter_bat_tracking,
-    statcast_batter_run_value
+    statcast_batter_run_value,
 )
 
 
@@ -22,17 +22,18 @@ def test_statcast_batter_exitvelo_barrels() -> None:
 
     assert len(result.columns) == 18
     assert len(result) > 0
-    assert len(result[result['attempts'] < min_bbe]) == 0
+    assert len(result[result["attempts"] < min_bbe]) == 0
 
 
 def test_statcast_batter() -> None:
-    result: pd.DataFrame = statcast_batter('2019-01-01', '2019-12-31', 642715)
+    result: pd.DataFrame = statcast_batter("2019-01-01", "2019-12-31", 642715)
 
     assert result is not None
     assert not result.empty
 
     assert len(result.columns) == CURRENT_SC_COLUMNS
     assert len(result) > 0
+
 
 def test_statcast_batter_expected_stats() -> None:
     min_pa = 250
@@ -42,7 +43,8 @@ def test_statcast_batter_expected_stats() -> None:
     assert not result.empty
 
     assert len(result) > 0
-    assert len(result[result['pa'] < min_pa]) == 0
+    assert len(result[result["pa"] < min_pa]) == 0
+
 
 def test_statcast_batter_percentile_ranks() -> None:
     result: pd.DataFrame = statcast_batter_percentile_ranks(2019)
@@ -52,6 +54,7 @@ def test_statcast_batter_percentile_ranks() -> None:
 
     assert len(result) > 0
 
+
 def test_statcast_batter_pitch_arsenal() -> None:
     min_pa = 25
     result: pd.DataFrame = statcast_batter_pitch_arsenal(2019, min_pa)
@@ -60,7 +63,8 @@ def test_statcast_batter_pitch_arsenal() -> None:
     assert not result.empty
 
     assert len(result) > 0
-    assert len(result[result['pa'] < min_pa]) == 0
+    assert len(result[result["pa"] < min_pa]) == 0
+
 
 def test_statcast_batter_bat_tracking() -> None:
     min_pa = 25
@@ -70,7 +74,8 @@ def test_statcast_batter_bat_tracking() -> None:
     assert not result.empty
 
     assert len(result) > 0
-    assert len(result[result['competitive_swings'] < min_pa]) == 0
+    assert len(result[result["competitive_swings"] < min_pa]) == 0
+
 
 def test_statcast_batter_run_value() -> None:
     result: pd.DataFrame = statcast_batter_run_value(2024)

--- a/tests/integration/pybaseball/test_statcast_batter.py
+++ b/tests/integration/pybaseball/test_statcast_batter.py
@@ -40,7 +40,6 @@ def test_statcast_batter_expected_stats() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 15
     assert len(result) > 0
     assert len(result[result['pa'] < min_pa]) == 0
 
@@ -50,7 +49,6 @@ def test_statcast_batter_percentile_ranks() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 17
     assert len(result) > 0
 
 def test_statcast_batter_pitch_arsenal() -> None:
@@ -60,9 +58,9 @@ def test_statcast_batter_pitch_arsenal() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 21
     assert len(result) > 0
     assert len(result[result['pa'] < min_pa]) == 0
+
 def test_statcast_batter_bat_tracking() -> None:
     min_pa = 25
     result: pd.DataFrame = statcast_batter_bat_tracking(2024, min_pa)
@@ -70,6 +68,5 @@ def test_statcast_batter_bat_tracking() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 18
     assert len(result) > 0
-    assert len(result[result['swings_competitive'] < min_pa]) == 0
+    assert len(result[result['competitive_swings'] < min_pa]) == 0

--- a/tests/integration/pybaseball/test_statcast_batter.py
+++ b/tests/integration/pybaseball/test_statcast_batter.py
@@ -8,7 +8,8 @@ from pybaseball.statcast_batter import (
     statcast_batter_expected_stats,
     statcast_batter_percentile_ranks,
     statcast_batter_pitch_arsenal,
-    statcast_batter_bat_tracking
+    statcast_batter_bat_tracking,
+    statcast_batter_run_value
 )
 
 
@@ -70,3 +71,11 @@ def test_statcast_batter_bat_tracking() -> None:
 
     assert len(result) > 0
     assert len(result[result['competitive_swings'] < min_pa]) == 0
+
+def test_statcast_batter_run_value() -> None:
+    result: pd.DataFrame = statcast_batter_run_value(2024)
+
+    assert result is not None
+    assert not result.empty
+
+    assert len(result) > 0

--- a/tests/integration/pybaseball/test_statcast_fielding.py
+++ b/tests/integration/pybaseball/test_statcast_fielding.py
@@ -1,100 +1,108 @@
 import pandas as pd
 
 from pybaseball.statcast_fielding import (
-	statcast_outs_above_average,
-	statcast_outfield_directional_oaa,
-	statcast_outfield_catch_prob,
-	statcast_outfielder_jump,
-	statcast_catcher_poptime,
-	statcast_catcher_framing,
-	statcast_fielding_run_value
+    statcast_outs_above_average,
+    statcast_outfield_directional_oaa,
+    statcast_outfield_catch_prob,
+    statcast_outfielder_jump,
+    statcast_catcher_poptime,
+    statcast_catcher_framing,
+    statcast_fielding_run_value,
 )
 
+
 def test_statcast_outs_above_average() -> None:
-	min_att = 50
-	pos = "of"
-	result: pd.DataFrame = statcast_outs_above_average(2019, pos, min_att)
+    min_att = 50
+    pos = "of"
+    result: pd.DataFrame = statcast_outs_above_average(2019, pos, min_att)
 
-	assert result is not None
-	assert not result.empty
-	print(result)
+    assert result is not None
+    assert not result.empty
+    print(result)
 
-	assert [result.year == 2019]
-	assert len(result) > 0
+    assert [result.year == 2019]
+    assert len(result) > 0
+
 
 def test_statcast_outs_above_average_view() -> None:
-	min_att = 50
-	pos = "of"
-	view = "Pitcher"
-	result: pd.DataFrame = statcast_outs_above_average(2019, pos, min_att, view)
+    min_att = 50
+    pos = "of"
+    view = "Pitcher"
+    result: pd.DataFrame = statcast_outs_above_average(2019, pos, min_att, view)
 
-	assert result is not None
-	assert not result.empty
+    assert result is not None
+    assert not result.empty
 
-	assert len(result) > 0
+    assert len(result) > 0
+
 
 def test_statcast_outfield_directional_oaa() -> None:
-	min_opp = 50
-	result: pd.DataFrame = statcast_outfield_directional_oaa(2019, min_opp)
+    min_opp = 50
+    result: pd.DataFrame = statcast_outfield_directional_oaa(2019, min_opp)
 
-	assert result is not None
-	assert not result.empty
+    assert result is not None
+    assert not result.empty
 
-	#assert len(result.columns) == 13
-	assert len(result) > 0
-	assert len(result.loc[result.attempts < min_opp]) == 0
+    # assert len(result.columns) == 13
+    assert len(result) > 0
+    assert len(result.loc[result.attempts < min_opp]) == 0
+
 
 def test_statcast_outfield_catch_prob() -> None:
-	min_opp = 25
-	result: pd.DataFrame = statcast_outfield_catch_prob(2019, min_opp)
+    min_opp = 25
+    result: pd.DataFrame = statcast_outfield_catch_prob(2019, min_opp)
 
-	assert result is not None
-	assert not result.empty
+    assert result is not None
+    assert not result.empty
 
-	assert len(result) > 0
+    assert len(result) > 0
 
 
-def test_statcast_outfielder_jump() -> None:		
-	min_att = 50
-	result: pd.DataFrame = statcast_outfielder_jump(2019, min_att)
-	
-	assert result is not None
-	assert not result.empty
+def test_statcast_outfielder_jump() -> None:
+    min_att = 50
+    result: pd.DataFrame = statcast_outfielder_jump(2019, min_att)
 
-	#assert len(result.columns) == 13
-	assert len(result) > 0
-	assert len(result.loc[result.n < min_att]) == 0
+    assert result is not None
+    assert not result.empty
+
+    # assert len(result.columns) == 13
+    assert len(result) > 0
+    assert len(result.loc[result.n < min_att]) == 0
+
 
 def test_statcast_catcher_poptime() -> None:
-	min_2b_att = 5
-	min_3b_att = 0
-	result: pd.DataFrame = statcast_catcher_poptime(2019, min_2b_att, min_3b_att) 
+    min_2b_att = 5
+    min_3b_att = 0
+    result: pd.DataFrame = statcast_catcher_poptime(2019, min_2b_att, min_3b_att)
 
-	assert result is not None
-	assert not result.empty
+    assert result is not None
+    assert not result.empty
 
-	assert len(result) > 0
-	assert len(result.loc[result.pop_2b_sba_count < min_2b_att]) == 0
-	assert len(result.loc[result.pop_3b_sba_count < min_3b_att]) == 0
+    assert len(result) > 0
+    assert len(result.loc[result.pop_2b_sba_count < min_2b_att]) == 0
+    assert len(result.loc[result.pop_3b_sba_count < min_3b_att]) == 0
+
 
 def test_statcast_catcher_framing() -> None:
-	min_called_p = 100
-	result: pd.DataFrame = statcast_catcher_framing(2019, min_called_p)
+    min_called_p = 100
+    result: pd.DataFrame = statcast_catcher_framing(2019, min_called_p)
 
-	assert result is not None
-	assert not result.empty
+    assert result is not None
+    assert not result.empty
 
-	assert len(result) > 0
-	assert len(result.loc[result.pitches < min_called_p]) == 0
+    assert len(result) > 0
+    assert len(result.loc[result.pitches < min_called_p]) == 0
+
 
 def test_statcast_fielding_run_value() -> None:
-	min_inn = 50
-	pos = 4
-	result: pd.DataFrame = statcast_fielding_run_value(2019, pos, min_inn)
-	assert result is not None
-	assert not result.empty
+    min_inn = 50
+    pos = 4
+    result: pd.DataFrame = statcast_fielding_run_value(2019, pos, min_inn)
+    assert result is not None
+    assert not result.empty
 
-	assert len(result) > 0
+    assert len(result) > 0
 
-#test_statcast_outs_above_average_view()
+
+# test_statcast_outs_above_average_view()
 test_statcast_outs_above_average()

--- a/tests/integration/pybaseball/test_statcast_fielding.py
+++ b/tests/integration/pybaseball/test_statcast_fielding.py
@@ -17,8 +17,9 @@ def test_statcast_outs_above_average() -> None:
 
 	assert result is not None
 	assert not result.empty
+	print(result)
 
-	assert len(result.columns) == 16
+	assert [result.year == 2019]
 	assert len(result) > 0
 
 def test_statcast_outs_above_average_view() -> None:
@@ -30,7 +31,6 @@ def test_statcast_outs_above_average_view() -> None:
 	assert result is not None
 	assert not result.empty
 
-	assert len(result.columns) == 17
 	assert len(result) > 0
 
 def test_statcast_outfield_directional_oaa() -> None:
@@ -40,7 +40,7 @@ def test_statcast_outfield_directional_oaa() -> None:
 	assert result is not None
 	assert not result.empty
 
-	assert len(result.columns) == 13
+	#assert len(result.columns) == 13
 	assert len(result) > 0
 	assert len(result.loc[result.attempts < min_opp]) == 0
 
@@ -51,8 +51,8 @@ def test_statcast_outfield_catch_prob() -> None:
 	assert result is not None
 	assert not result.empty
 
-	assert len(result.columns) == 19
 	assert len(result) > 0
+
 
 def test_statcast_outfielder_jump() -> None:		
 	min_att = 50
@@ -61,7 +61,7 @@ def test_statcast_outfielder_jump() -> None:
 	assert result is not None
 	assert not result.empty
 
-	assert len(result.columns) == 13
+	#assert len(result.columns) == 13
 	assert len(result) > 0
 	assert len(result.loc[result.n < min_att]) == 0
 
@@ -73,7 +73,6 @@ def test_statcast_catcher_poptime() -> None:
 	assert result is not None
 	assert not result.empty
 
-	assert len(result.columns) == 14
 	assert len(result) > 0
 	assert len(result.loc[result.pop_2b_sba_count < min_2b_att]) == 0
 	assert len(result.loc[result.pop_3b_sba_count < min_3b_att]) == 0
@@ -85,19 +84,16 @@ def test_statcast_catcher_framing() -> None:
 	assert result is not None
 	assert not result.empty
 
-	assert len(result.columns) == 15
 	assert len(result) > 0
-	assert len(result.loc[result.n_called_pitches < min_called_p]) == 0
+	assert len(result.loc[result.pitches < min_called_p]) == 0
 
 def test_statcast_fielding_run_value() -> None:
 	min_inn = 50
 	pos = 4
 	result: pd.DataFrame = statcast_fielding_run_value(2019, pos, min_inn)
-
 	assert result is not None
 	assert not result.empty
 
-	assert len(result.columns) == 22
 	assert len(result) > 0
 
 #test_statcast_outs_above_average_view()

--- a/tests/integration/pybaseball/test_statcast_pitcher.py
+++ b/tests/integration/pybaseball/test_statcast_pitcher.py
@@ -12,7 +12,8 @@ from pybaseball.statcast_pitcher import (
     statcast_pitcher_pitch_arsenal,
     statcast_pitcher_pitch_movement,
     statcast_pitcher_spin_dir_comp,
-    statcast_pitcher_bat_tracking
+    statcast_pitcher_bat_tracking,
+    statcast_pitcher_run_value
 )
 
 
@@ -32,7 +33,6 @@ def test_statcast_pitcher_exitvelo_barrels() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 18
     assert len(result) > 0
     assert len(result[result['attempts'] < min_bbe]) == 0
 
@@ -43,7 +43,6 @@ def test_statcast_pitchers_expected_stats() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 17
     assert len(result) > 0
     assert len(result[result['pa'] < min_pa]) == 0
 
@@ -54,7 +53,6 @@ def test_statcast_pitcher_pitch_arsenal() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 12
     assert len(result) > 0
 
 def test_statcast_pitcher_arsenal_stats() -> None:
@@ -64,7 +62,6 @@ def test_statcast_pitcher_arsenal_stats() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 20
     assert len(result) > 0
     assert len(result[result['pa'] < min_pa]) == 0
 
@@ -75,7 +72,6 @@ def test_statcast_pitcher_pitch_movement() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 24
     assert len(result) > 0
     assert len(result[result['pitches_thrown'] < min_p]) == 0
 
@@ -86,7 +82,6 @@ def test_statcast_pitcher_active_spin() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 12
     assert len(result) > 0
 
 def test_statcast_pitcher_percentile_ranks() -> None:
@@ -95,7 +90,6 @@ def test_statcast_pitcher_percentile_ranks() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 22
     assert len(result) > 0
 
 def test_statcast_pitcher_spin_dir_comp() -> None:
@@ -104,7 +98,6 @@ def test_statcast_pitcher_spin_dir_comp() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 29
     assert len(result) > 100
 def test_statcast_pitcher_bat_tracking() -> None:
     result: pd.DataFrame = statcast_pitcher_bat_tracking(2024)
@@ -112,5 +105,12 @@ def test_statcast_pitcher_bat_tracking() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 13
+    assert len(result) > 0
+
+def test_statcast_pitcher_run_value() -> None:
+    result: pd.DataFrame = statcast_pitcher_run_value(2024)
+
+    assert result is not None
+    assert not result.empty
+
     assert len(result) > 0

--- a/tests/integration/pybaseball/test_statcast_pitcher.py
+++ b/tests/integration/pybaseball/test_statcast_pitcher.py
@@ -13,18 +13,19 @@ from pybaseball.statcast_pitcher import (
     statcast_pitcher_pitch_movement,
     statcast_pitcher_spin_dir_comp,
     statcast_pitcher_bat_tracking,
-    statcast_pitcher_run_value
+    statcast_pitcher_run_value,
 )
 
 
 def test_statcast_pitcher() -> None:
-    result: pd.DataFrame = statcast_pitcher('2019-01-01', '2019-12-31', 605483)
+    result: pd.DataFrame = statcast_pitcher("2019-01-01", "2019-12-31", 605483)
 
     assert result is not None
     assert not result.empty
 
     assert len(result.columns) == CURRENT_SC_COLUMNS
     assert len(result) > 0
+
 
 def test_statcast_pitcher_exitvelo_barrels() -> None:
     min_bbe = 100
@@ -34,7 +35,8 @@ def test_statcast_pitcher_exitvelo_barrels() -> None:
     assert not result.empty
 
     assert len(result) > 0
-    assert len(result[result['attempts'] < min_bbe]) == 0
+    assert len(result[result["attempts"] < min_bbe]) == 0
+
 
 def test_statcast_pitchers_expected_stats() -> None:
     min_pa = 100
@@ -44,7 +46,8 @@ def test_statcast_pitchers_expected_stats() -> None:
     assert not result.empty
 
     assert len(result) > 0
-    assert len(result[result['pa'] < min_pa]) == 0
+    assert len(result[result["pa"] < min_pa]) == 0
+
 
 def test_statcast_pitcher_pitch_arsenal() -> None:
     min_p = 250
@@ -55,6 +58,7 @@ def test_statcast_pitcher_pitch_arsenal() -> None:
 
     assert len(result) > 0
 
+
 def test_statcast_pitcher_arsenal_stats() -> None:
     min_pa = 25
     result: pd.DataFrame = statcast_pitcher_arsenal_stats(2019, min_pa)
@@ -63,7 +67,8 @@ def test_statcast_pitcher_arsenal_stats() -> None:
     assert not result.empty
 
     assert len(result) > 0
-    assert len(result[result['pa'] < min_pa]) == 0
+    assert len(result[result["pa"] < min_pa]) == 0
+
 
 def test_statcast_pitcher_pitch_movement() -> None:
     min_p = 250
@@ -73,7 +78,8 @@ def test_statcast_pitcher_pitch_movement() -> None:
     assert not result.empty
 
     assert len(result) > 0
-    assert len(result[result['pitches_thrown'] < min_p]) == 0
+    assert len(result[result["pitches_thrown"] < min_p]) == 0
+
 
 def test_statcast_pitcher_active_spin() -> None:
     min_p = 250
@@ -84,6 +90,7 @@ def test_statcast_pitcher_active_spin() -> None:
 
     assert len(result) > 0
 
+
 def test_statcast_pitcher_percentile_ranks() -> None:
     result: pd.DataFrame = statcast_pitcher_percentile_ranks(2019)
 
@@ -92,6 +99,7 @@ def test_statcast_pitcher_percentile_ranks() -> None:
 
     assert len(result) > 0
 
+
 def test_statcast_pitcher_spin_dir_comp() -> None:
     result: pd.DataFrame = statcast_pitcher_spin_dir_comp(2020)
 
@@ -99,6 +107,8 @@ def test_statcast_pitcher_spin_dir_comp() -> None:
     assert not result.empty
 
     assert len(result) > 100
+
+
 def test_statcast_pitcher_bat_tracking() -> None:
     result: pd.DataFrame = statcast_pitcher_bat_tracking(2024)
 
@@ -106,6 +116,7 @@ def test_statcast_pitcher_bat_tracking() -> None:
     assert not result.empty
 
     assert len(result) > 0
+
 
 def test_statcast_pitcher_run_value() -> None:
     result: pd.DataFrame = statcast_pitcher_run_value(2024)

--- a/tests/integration/pybaseball/test_statcast_pitcher.py
+++ b/tests/integration/pybaseball/test_statcast_pitcher.py
@@ -43,7 +43,7 @@ def test_statcast_pitchers_expected_stats() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 18
+    assert len(result.columns) == 17
     assert len(result) > 0
     assert len(result[result['pa'] < min_pa]) == 0
 
@@ -54,7 +54,7 @@ def test_statcast_pitcher_pitch_arsenal() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 11
+    assert len(result.columns) == 12
     assert len(result) > 0
 
 def test_statcast_pitcher_arsenal_stats() -> None:
@@ -64,7 +64,7 @@ def test_statcast_pitcher_arsenal_stats() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 21
+    assert len(result.columns) == 20
     assert len(result) > 0
     assert len(result[result['pa'] < min_pa]) == 0
 
@@ -86,7 +86,7 @@ def test_statcast_pitcher_active_spin() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 10
+    assert len(result.columns) == 12
     assert len(result) > 0
 
 def test_statcast_pitcher_percentile_ranks() -> None:
@@ -95,7 +95,7 @@ def test_statcast_pitcher_percentile_ranks() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 19
+    assert len(result.columns) == 22
     assert len(result) > 0
 
 def test_statcast_pitcher_spin_dir_comp() -> None:
@@ -104,7 +104,7 @@ def test_statcast_pitcher_spin_dir_comp() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 30
+    assert len(result.columns) == 29
     assert len(result) > 100
 def test_statcast_pitcher_bat_tracking() -> None:
     result: pd.DataFrame = statcast_pitcher_bat_tracking(2024)
@@ -112,5 +112,5 @@ def test_statcast_pitcher_bat_tracking() -> None:
     assert result is not None
     assert not result.empty
 
-    assert len(result.columns) == 18
+    assert len(result.columns) == 13
     assert len(result) > 0


### PR DESCRIPTION
This PR adds Statcast's Attack Zone tool to PyBaseball. 

Run Values are a sabermetric tool used to measure offensive production. In 2019, the Baseball Savant added the ability to measure Run Values in a pre-defined "Attack Zone"

Run Values/Attack Zone Documentation: https://tangotiger.com/index.php/site/article/statcast-lab-swing-take-and-a-primer-on-run-value

In 2025, Atlanta Braves shortstop Ozzie Albies tallied -29 Runs in the Shadow Zone, last in the Majors   

-----------------------------------

### Changes Made: 
1. Added function _statcast_pitcher_run_value_ in _statcast_pitcher_ file 
      - Added try/except/finally clause designed to return HTTP Error if website cannot be reached
      - Created Tests in _test_statcast_pitcher_ to test function

2. Added function _statcast_batter_run_value_ in _statcast_batter_ file 
      - Added try/except/finally clause designed to return HTTP Error if website cannot to be reached
      - Created Tests in _test_statcast_batter_ to test function


3. General Improvements: 
- Fixed Issue within Baseball Savant Modules where the minimum queries were not formatted properly in the URL
- Fixed several tests in _statcast_pitcher_, _statcast_batter_, _statcast_fielding_ that were failing
    - These tests were failing on the number of columns returned, which was predefined, static, and stale once the Savant Team added the new columns to the Savant CSVs 
- Ran Ruff on Modules Changed

###### Used https://github.com/jldbc/pybaseball/pull/430 as inspiration

###### This is my first open-source contribution anywhere so any feedback would be welcomed 