### PR TITLE
fix: resolve Lahman data loading and remove debug output

### DIFF
--- a/pybaseball/lahman.py
+++ b/pybaseball/lahman.py
@@ -8,7 +8,7 @@ import requests
 
 from . import cache
 
-url = "https://github.com/chadwickbureau/baseballdatabank/archive/master.zip"
+url = "https://github.com/seanlahman/baseballdatabank/archive/refs/heads/master.zip"
 base_string = "baseballdatabank-master"
 
 _handle = None
@@ -106,7 +106,11 @@ def master() -> pd.DataFrame:
     return people()
 
 def people() -> pd.DataFrame:
-    return _get_file("core/People.csv")
+    # Try new naming first (People.csv), fallback to old naming (Master.csv)
+    try:
+        return _get_file("core/People.csv")
+    except (FileNotFoundError, KeyError):
+        return _get_file("core/Master.csv")
 
 def pitching() -> pd.DataFrame:
     return _get_file("core/Pitching.csv")

--- a/pybaseball/team_results.py
+++ b/pybaseball/team_results.py
@@ -19,7 +19,6 @@ def get_soup(season: Optional[int], team: str) -> BeautifulSoup:
     if season is None:
         season = most_recent_season()
     url = "https://www.baseball-reference.com/teams/{}/{}-schedule-scores.shtml".format(team, season)
-    print(url)
     s = session.get(url).content
     return BeautifulSoup(s, "lxml")
 


### PR DESCRIPTION
## Summary

Fix Lahman database loading (404 error) and remove debug print statement.

## Changes

- **lahman.py**: Update deprecated `chadwickbureau/baseballdatabank` URL to working `seanlahman/baseballdatabank`
- **lahman.py**: Add `Master.csv` fallback for compatibility with older database versions
- **team_results.py**: Remove debug `print(url)` statement

## Related Issues

Fixes #489 (Lahman data loading)

## Testing

```python
>>> from pybaseball import lahman
>>> lahman.people()
# Returns 19,105 rows ✅