### PR TITLE
docs: fix function name typo in statcast_pitcher_spin.md

### DIFF
--- a/docs/statcast_pitcher_spin.md
+++ b/docs/statcast_pitcher_spin.md
@@ -1,5 +1,5 @@
 # Statcast Pitcher Spin
-`statcast_pitcher(start_dt=[yesterday's date], end_dt=None, player_id)`
+`statcast_pitcher_spin(start_dt=[yesterday's date], end_dt=None, player_id)`
 
 The statcast function retrieves pitch-level statcast data for a given date or range or dates and calculates spin related metrics.
 


### PR DESCRIPTION
## Summary

Fix typo in `docs/statcast_pitcher_spin.md`: the function signature at the top of the file incorrectly shows `statcast_pitcher` instead of `statcast_pitcher_spin`.

Closes #490

## Changes

- `statcast_pitcher(start_dt=...)` → `statcast_pitcher_spin(start_dt=...)`