### PR TITLE
fix: replace deprecated errors='ignore' with explicit try/except

### DIFF
--- a/pybaseball/datahelpers/postprocessing.py
+++ b/pybaseball/datahelpers/postprocessing.py
@@ -30,11 +30,12 @@ def try_parse_dataframe(
 
     if parse_numerics:
         data_copy = coalesce_nulls(data_copy, null_replacement)
-        data_copy = data_copy.apply(
-            pd.to_numeric,
-            errors='ignore',
-            downcast='signed'
-        ).convert_dtypes(convert_string=False)
+        for col in data_copy.columns:
+            try:
+                data_copy[col] = pd.to_numeric(data_copy[col], downcast='signed')
+            except (ValueError, TypeError):
+                pass
+        data_copy = data_copy.convert_dtypes(convert_string=False)
 
     string_columns = [
         dtype_tuple[0] for dtype_tuple in data_copy.dtypes.items() if str(dtype_tuple[1]) in ["object", "string"]

--- a/tests/pybaseball/test_statcast.py
+++ b/tests/pybaseball/test_statcast.py
@@ -18,7 +18,10 @@ def _single_game_raw(get_data_file_contents: Callable[[str], str]) -> str:
 @pytest.fixture(name="single_game")
 def _single_game(get_data_file_dataframe: GetDataFrameCallable) -> pd.DataFrame:
     data = get_data_file_dataframe('single_game_request.csv', parse_dates=[2])
-    data[data.columns[2]].apply(pd.to_datetime, errors='ignore', format=DATE_FORMAT)
+    try:
+        data[data.columns[2]] = pd.to_datetime(data[data.columns[2]], format=DATE_FORMAT)
+    except (ValueError, TypeError):
+        pass
     return data
 
 


### PR DESCRIPTION
## Summary

Replace deprecated `errors='ignore'` parameter in `pd.to_numeric` and `pd.to_datetime` calls with explicit `try/except` blocks.

Closes #467

## Changes

### `pybaseball/datahelpers/postprocessing.py`
- Replace `DataFrame.apply(pd.to_numeric, errors='ignore', downcast='signed')` with a column-by-column `try/except` approach
- Same behavior: columns that can't be converted to numeric are left unchanged

### `tests/pybaseball/test_statcast.py`
- Replace `Series.apply(pd.to_datetime, errors='ignore', ...)` with `try/except` block

## Context

Since pandas 2.2, passing `errors='ignore'` to `pd.to_numeric` and `pd.to_datetime` raises `FutureWarning`:

> FutureWarning: errors='ignore' is deprecated and will raise in a future version.

This warning is emitted once per day in the query when using `statcast()`, making output noisy. The fix follows pandas' recommendation to catch exceptions explicitly.