### PR TITLE
Fix FutureWarning in team_results.py

### DIFF
--- a/pybaseball/team_results.py
+++ b/pybaseball/team_results.py
@@ -72,7 +72,7 @@ def get_table(soup: BeautifulSoup, team: str) -> pd.DataFrame:
     df = df.rename(columns=df.iloc[0])
     df = df.reindex(df.index.drop(0))
     df = df.drop('', axis=1) #not a useful column
-    df['Attendance'].replace(r'^Unknown$', np.nan, regex=True, inplace = True) # make this a NaN so the column can benumeric
+    df['Attendance'] = df['Attendance'].replace(r'^Unknown$', np.nan, regex=True) # make this a NaN so the column can be numeric
     return df
 
 def process_win_streak(data: pd.DataFrame) -> pd.DataFrame:

--- a/tests/pybaseball/data/team_results.html
+++ b/tests/pybaseball/data/team_results.html
@@ -1,0 +1,12 @@
+<html><body>
+<table>
+<thead>
+<tr><th>Gm#</th><th>Date</th><th>Tm</th><th>Opp</th><th>HA</th><th>WL</th><th>R</th><th>RA</th><th>Inn</th><th>Rank</th><th>GB</th><th>Win</th><th>Loss</th><th>Save</th><th>Time</th><th>DN</th><th>Streak</th><th>Attendance</th><th></th></tr>
+</thead>
+<tbody>
+<tr><td>2019-04-01</td><td>NYY</td><td>BAL</td><td>Home</td><td>W</td><td>5</td><td>3</td><td>9</td><td>1</td><td>--</td><td>SmithA</td><td>JonesB</td><td>None</td><td>3:01</td><td>D</td><td>+1</td><td>Unknown</td><td>x</td></tr>
+<tr><td>2019-04-02</td><td>NYY</td><td>BAL</td><td>Home</td><td>L</td><td>2</td><td>4</td><td>9</td><td>2</td><td>1.0</td><td>DoeC</td><td>RoeD</td><td>None</td><td>2:55</td><td>N</td><td>-1</td><td>40,000</td><td>x</td></tr>
+<tr><td>Description row to be skipped</td></tr>
+</tbody>
+</table>
+</body></html>

--- a/tests/pybaseball/test_team_results.py
+++ b/tests/pybaseball/test_team_results.py
@@ -1,0 +1,19 @@
+from typing import Callable
+
+from bs4 import BeautifulSoup
+
+from pybaseball.team_results import get_table
+
+
+def test_get_table_unknown_attendance_becomes_nan(get_data_file_contents: Callable[[str], str]) -> None:
+    # Regression test for #459: 'Unknown' attendance values must be converted to
+    # NaN so the column can be made numeric. The previous chained-assignment
+    # `inplace=True` form silently failed under pandas copy-on-write (and emitted
+    # a FutureWarning), leaving the value as the string 'Unknown'.
+    soup = BeautifulSoup(get_data_file_contents('team_results.html'), 'lxml')
+
+    result = get_table(soup, 'NYY')
+
+    assert 'Attendance' in result.columns
+    assert result['Attendance'].isna().any()
+    assert 'Unknown' not in result['Attendance'].tolist()


### PR DESCRIPTION
## Summary
- Fix `FutureWarning` caused by chained assignment with `inplace=True` in `team_results.py` (line 75)
- Replace `df['Attendance'].replace(..., inplace=True)` with `df['Attendance'] = df['Attendance'].replace(...)` as recommended by pandas

Closes #459

## Details
pandas 3.0 deprecates chained assignment using inplace methods. The fix follows the recommended pattern from the warning message.

**Before:**
```python
df['Attendance'].replace(r'^Unknown$', np.nan, regex=True, inplace = True)
```

**After:**
```python
df['Attendance'] = df['Attendance'].replace(r'^Unknown$', np.nan, regex=True)
```