### PR TITLE
Add input validation to team_fielding_bref

### DIFF
--- a/pybaseball/team_fielding.py
+++ b/pybaseball/team_fielding.py
@@ -32,7 +32,12 @@ def team_fielding_bref(team: str, start_season: int, end_season: Optional[int]=N
         )
     if end_season is None:
         end_season = start_season
+    if end_season < start_season:
+        raise ValueError(
+            "end_season must be greater than or equal to start_season."
+        )
 
+    team = team.upper()
     url = "https://www.baseball-reference.com/teams/{}".format(team)
 
     raw_data = []

--- a/tests/pybaseball/test_team_fielding.py
+++ b/tests/pybaseball/test_team_fielding.py
@@ -25,3 +25,12 @@ def test_team_fielding(response_get_monkeypatch: Callable, sample_html: str, sam
     team_fielding_result = team_fielding(season).reset_index(drop=True)
 
     pd.testing.assert_frame_equal(team_fielding_result, sample_processed_result, check_dtype=False)
+
+
+def test_team_fielding_bref_invalid_season_range() -> None:
+    # Regression test for #462: an end_season earlier than start_season should
+    # raise a clear ValueError before any network request is made.
+    from pybaseball.team_fielding import team_fielding_bref
+
+    with pytest.raises(ValueError):
+        team_fielding_bref('NYY', 2019, 2018)


### PR DESCRIPTION
## Summary
- Add `team.upper()` to handle case-insensitive team abbreviations (e.g., `"oak"` → `"OAK"`)
- Add `end_season < start_season` validation with a clear error message

Closes #462

## Details
Previously, passing a lowercase team abbreviation like `"oak"` caused an `AttributeError` because the URL constructed with the lowercase string returned no matching HTML elements. Adding `.upper()` follows the same pattern used in `team_results.py`.

Additionally, passing `end_season` before `start_season` (e.g., `team_fielding_bref("NYY", 2023, 2020)`) silently returned an empty DataFrame. Now it raises a `ValueError` with a clear message.