### PR TITLE
Fix team_ids returning empty data for seasons after 2021

### DIFF
--- a/pybaseball/teamid_lookup.py
+++ b/pybaseball/teamid_lookup.py
@@ -24,6 +24,16 @@ def team_ids(season: Optional[int] = None, league: str = 'ALL') -> pd.DataFrame:
 
     fg_team_data = pd.read_csv(_DATA_FILENAME, index_col=0)
 
+    max_year = int(fg_team_data['yearID'].max())
+
+    # If the requested season is beyond the data, extrapolate from the last known year.
+    # MLB team composition hasn't changed since 2021 (when the bundled data ends),
+    # so it's safe to reuse the last year's data for recent seasons.
+    if season is not None and season > max_year:
+        last_year_data = fg_team_data[fg_team_data['yearID'] == max_year].copy()
+        last_year_data['yearID'] = season
+        fg_team_data = pd.concat([fg_team_data, last_year_data], ignore_index=True)
+
     if season is not None:
         fg_team_data = fg_team_data.query(f"yearID == {season}")
 

--- a/tests/pybaseball/test_teamid_lookup.py
+++ b/tests/pybaseball/test_teamid_lookup.py
@@ -141,3 +141,21 @@ def test_get_close_team_matches() -> None:
 
     for _, row in lahman_teams.iterrows():
         assert _get_close_team_matches(row, fg_teams) == row.expected
+
+
+def test_team_id_lookup_recent_season() -> None:
+    # Regression test for #486: seasons after the bundled data's final year
+    # previously returned an empty DataFrame. team_ids should now extrapolate
+    # from the most recent known year, since MLB team composition is unchanged.
+    from pybaseball.teamid_lookup import _DATA_FILENAME
+
+    max_year = int(pd.read_csv(_DATA_FILENAME, index_col=0)['yearID'].max())
+    recent_season = max_year + 2
+
+    result = team_ids(recent_season)
+
+    assert result is not None
+    assert not result.empty
+    assert len(result.columns) == 7
+    assert len(result) == 30
+    assert (result['yearID'] == recent_season).all()


### PR DESCRIPTION
## Summary
- Fix `team_ids()` returning empty DataFrame for seasons 2022+
- Extrapolate from the last known year (2021) when a more recent season is requested

Closes #486

## Details
The bundled `fangraphs_teams.csv` ends at 2021 because the upstream Lahman/Retrosheet data hasn't been updated (see https://www.retrosheet.org/TeamIDs.htm). Since MLB team composition hasn't changed since 2021 (no expansions, relocations with ID changes, or contractions), it's safe to reuse the last year's team data for recent seasons.

**Before:**
```python
>>> team_ids(2023)
Empty DataFrame
```

**After:**
```python
>>> team_ids(2023)
# Returns 30 teams (extrapolated from 2021 data)
```

The fix only activates when a specific season is requested that exceeds the data range. Calling `team_ids()` without a season still returns only the actual data (up to 2021).