### PR TITLE
Avoid inplace replace on Attendance Series

### DIFF
--- a/pybaseball/team_results.py
+++ b/pybaseball/team_results.py
@@ -72,7 +72,7 @@ def get_table(soup: BeautifulSoup, team: str) -> pd.DataFrame:
     df = df.rename(columns=df.iloc[0])
     df = df.reindex(df.index.drop(0))
     df = df.drop('', axis=1) #not a useful column
-    df['Attendance'].replace(r'^Unknown$', np.nan, regex=True, inplace = True) # make this a NaN so the column can benumeric
+    df['Attendance'] = df['Attendance'].replace(r'^Unknown$', np.nan, regex=True) # make this a NaN so the column can benumeric
     return df
 
 def process_win_streak(data: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
Replaces the inplace Attendance.replace() call with an explicit assignment.

A chained assignment error can occur with newer pandas versions when calling schedule_and_record(), and "Unknown" attendance values may not get converted to NaN before the float conversion step.

This change keeps the same behavior but avoids the Copy-on-Write/chained assignment issue.